### PR TITLE
Fix requirements and add Vercel install

### DIFF
--- a/backend/backend/requirements.txt
+++ b/backend/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 stripe
 httpx
+supabase-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-nginx
 fastapi
 uvicorn
 openai

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "installCommand": "pip install -r backend/backend/requirements.txt && npm install"
+}


### PR DESCRIPTION
## Summary
- remove `nginx` from `requirements.txt`
- add missing dependency to backend requirements
- configure Vercel to install backend Python deps

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685355b06bf08323839165fee46ec332