### PR TITLE
Update gitignore for Next.js build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,4 +193,5 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 node_modules/
+.next/
 


### PR DESCRIPTION
## Summary
- ignore `.next/` build folder

## Testing
- `npm test --silent` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68538168fdc08323b5758fad1b593e76