### PR TITLE
Fix tailwind config newline

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,4 +6,3 @@ module.exports = {
     },
     plugins: [],
   };
-  


### PR DESCRIPTION
## Summary
- clean up `tailwind.config.js` by removing leftover shell prompt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'stripe')*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539f9902488323a8e4cad7dc3f5f48