### PR TITLE
Pin Python deps and update webhook test

### DIFF
--- a/backend/backend/requirements.txt
+++ b/backend/backend/requirements.txt
@@ -1,4 +1,4 @@
-fastapi
-uvicorn[standard]
-stripe
-httpx
+fastapi==0.115.13
+uvicorn[standard]==0.34.3
+stripe==12.2.0
+httpx==0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-fastapi
-httpx
-langgraph
-openai<1.0
-pytest
-stripe
-supabase-py
-uvicorn
+fastapi==0.115.13
+httpx==0.28.1
+langgraph==0.4.8
+openai==1.88.0
+pytest==8.3.5
+stripe==12.2.0
+supabase==2.15.3
+uvicorn==0.34.3

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -42,7 +42,7 @@ def test_checkout_session_completed_creates_order(monkeypatch):
     supabase_mock.table.return_value.insert.return_value.execute = MagicMock()
     monkeypatch.setattr(main, "supabase", supabase_mock)
 
-    response = client.post("/api/webhook", data=b"{}", headers={"stripe-signature": "test"})
+    response = client.post("/api/webhook", content=b"{}", headers={"stripe-signature": "test"})
     assert response.status_code == 200
     supabase_mock.table.assert_called_with("orders")
     supabase_mock.table.return_value.insert.assert_called_once()


### PR DESCRIPTION
## Summary
- pin Python versions in requirements
- install supabase in test env
- fix webhook test to use `content=` rather than `data=`

## Testing
- `pip install supabase-py` *(fails: no matching distribution)*
- `pip install supabase`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853a1ebbfe4832395bff0b3a487950d