### PR TITLE
Remove Python requirements from Vercel config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r backend/backend/requirements.txt
       - name: Run tests
         run: pytest -q

--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ pip install -r backend/backend/requirements.txt
 uvicorn backend.main:app --reload
 ```
 This will launch the API at `http://localhost:8000`.
+
+### Vercel Build
+Vercel runs `scripts/vercel_build.sh` which installs backend dependencies before
+building the React app. This keeps the FastAPI backend functional in serverless
+deployments.

--- a/scripts/vercel_build.sh
+++ b/scripts/vercel_build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+pip install -r backend/backend/requirements.txt
+npm run build

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "pythonRequirementsFile": "backend/backend/requirements.txt",
-  "buildCommand": "npm run build",
+  "buildCommand": "bash scripts/vercel_build.sh",
   "outputDirectory": "build"
 }


### PR DESCRIPTION
## Summary
- drop pythonRequirementsFile from `vercel.json`
- create `scripts/vercel_build.sh` so Vercel still installs backend requirements
- document Vercel build step in README
- install backend requirements in CI workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cbd358488323ac57232c4a9dcdbb