### PR TITLE
Add route change hook

### DIFF
--- a/components/mobile-nav/mobile-nav.tsx
+++ b/components/mobile-nav/mobile-nav.tsx
@@ -12,7 +12,7 @@ import {
   useUpdateEffect,
 } from '@chakra-ui/react'
 import { Link } from '@saas-ui/react'
-import useRouteChanged from 'hooks/use-route-changed'
+import useRouteChanged from '../../src/hooks/use-route-changed'
 import { usePathname } from 'next/navigation'
 import { AiOutlineMenu } from 'react-icons/ai'
 import { RemoveScroll } from 'react-remove-scroll'

--- a/src/components/mobile-nav/mobile-nav.tsx
+++ b/src/components/mobile-nav/mobile-nav.tsx
@@ -12,7 +12,7 @@ import {
   useUpdateEffect,
 } from '@chakra-ui/react'
 import { Link } from '@saas-ui/react'
-import useRouteChanged from 'hooks/use-route-changed'
+import useRouteChanged from '../../hooks/use-route-changed'
 import { usePathname } from 'next/navigation'
 import { AiOutlineMenu } from 'react-icons/ai'
 import { RemoveScroll } from 'react-remove-scroll'

--- a/src/hooks/use-route-changed.ts
+++ b/src/hooks/use-route-changed.ts
@@ -1,0 +1,17 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { usePathname } from 'next/navigation'
+
+export default function useRouteChanged(callback: () => void) {
+  const pathname = usePathname()
+  const savedCallback = useRef(callback)
+
+  useEffect(() => {
+    savedCallback.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    savedCallback.current()
+  }, [pathname])
+}


### PR DESCRIPTION
## Summary
- add `useRouteChanged` hook listening to Next.js route changes
- update mobile nav imports

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d99c6b408323bc6aa11d105e085f