### PR TITLE
Document stripe/httpx

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ Run it locally with Uvicorn:
 pip install -r python-backend/requirements.txt
 uvicorn main:app --app-dir python-backend --reload
 ```
+The backend dependencies include `stripe` for payments and `httpx` for outbound HTTP calls.

--- a/python-backend/python-backend/requirements.txt
+++ b/python-backend/python-backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+python-dotenv
+stripe
+httpx


### PR DESCRIPTION
## Summary
- add a python-backend requirements file
- document stripe and httpx in backend setup steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856db5740c0832399467f31600313e8