### PR TITLE
Add tests and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,19 @@ pip install -r python-backend/requirements.txt
 uvicorn main:app --app-dir python-backend --reload
 ```
 The backend dependencies include `stripe` for payments and `httpx` for outbound HTTP calls.
+
+### Running Tests
+
+Frontend tests use Jest via `react-scripts`:
+```bash
+npm test
+```
+
+Backend tests are written with `pytest`:
+```bash
+pip install -r requirements.txt
+pip install -r backend/backend/requirements.txt
+pytest
+```
+
+Continuous integration runs these commands using `.github/workflows/ci.yml` whenever you push or open a pull request.

--- a/src/components/__tests__/Navbar.test.jsx
+++ b/src/components/__tests__/Navbar.test.jsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Navbar from '../Navbar';
+import { ThemeProvider } from '../../context/ThemeContext';
+
+test('renders site title', () => {
+  render(
+    <BrowserRouter>
+      <ThemeProvider>
+        <Navbar />
+      </ThemeProvider>
+    </BrowserRouter>
+  );
+  expect(screen.getByText('MyRoofGenius')).toBeInTheDocument();
+});

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -1,0 +1,47 @@
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def load_app(monkeypatch):
+    monkeypatch.setenv("CONVERTKIT_API_KEY", "test-key")
+    monkeypatch.setenv("CONVERTKIT_FORM_ID", "123")
+    spec = importlib.util.spec_from_file_location(
+        "backend_main", Path(__file__).resolve().parents[1] / "python-backend" / "main.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DummyAsyncClient:
+    def __init__(self):
+        self.post_called_with = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None, timeout=10):
+        self.post_called_with = (url, json)
+        return MagicMock(status_code=200, text="OK")
+
+
+def test_subscribe_success(monkeypatch):
+    main = load_app(monkeypatch)
+    dummy_client = DummyAsyncClient()
+    monkeypatch.setattr(main.httpx, "AsyncClient", lambda: dummy_client)
+    client = TestClient(main.app)
+
+    resp = client.post("/api/subscribe", json={"email": "user@example.com"})
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+    url, payload = dummy_client.post_called_with
+    assert "forms/123/subscribe" in url
+    assert payload["email"] == "user@example.com"


### PR DESCRIPTION
## Summary
- create pytest for `/api/subscribe`
- add a simple Navbar Jest test
- document running tests locally and in CI

## Testing
- `pytest -q`
- `npx jest --testPathPattern=src/components/__tests__/Navbar.test.jsx` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6856de3d4d7c8323b03b9bc88b1a1558