### PR TITLE
Add Python CI workflow for codex-ready

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,0 +1,26 @@
+name: CI Python
+
+on:
+  push:
+    branches: [codex-ready]
+  pull_request:
+    branches: [codex-ready]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install black
+          pip install -r requirements.txt
+          pip install -r backend/backend/requirements.txt
+      - name: Check formatting
+        run: black --check .
+      - name: Run tests
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add a `ci-python.yml` workflow running on `codex-ready`
- install dependencies, check formatting via **black**, and run tests

## Testing
- `black --check .` *(fails: would reformat multiple files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f3b7915c8323b8d3e24d95e6e081