### PR TITLE
Add global siteConfig object

### DIFF
--- a/data/config.ts
+++ b/data/config.ts
@@ -1,25 +1,86 @@
-import React from 'react';
-import { HardHat } from 'lucide-react';
+import React from 'react'
+import {
+  HardHat,
+  ShieldCheck,
+  Building2,
+  BrainCircuit,
+} from 'lucide-react'
 
+/**
+ * Logo component used across the site.
+ */
 export const Logo: React.FC = () => (
   <span className="inline-flex items-center font-bold">
     <HardHat size={18} className="mr-1" />
     MyRoofGenius
   </span>
-);
+)
 
-export const seo = {
-  title: 'MyRoofGenius',
-  description:
-    'Intelligent systems that protect every commercial roofing decision.',
-};
+const currentYear = new Date().getFullYear()
 
-export const footerLinks = [
-  { href: '/', label: 'Home' },
-  { href: '/services', label: 'Services' },
-  { href: '/about', label: 'About' },
-  { href: '/contact', label: 'Contact' },
-];
+/**
+ * Global site configuration
+ */
+const siteConfig = {
+  logo: Logo,
+  seo: {
+    title: 'MyRoofGenius',
+    description:
+      'Intelligent systems that protect every commercial roofing decision.',
+    titleTemplate: '%s – MyRoofGenius',
+    openGraph: {
+      type: 'website',
+      url: 'https://myroofgenius.com',
+      title: 'MyRoofGenius',
+      description:
+        'Intelligent systems that protect every commercial roofing decision.',
+    },
+    twitter: {
+      handle: '@myroofgenius',
+      site: '@myroofgenius',
+      cardType: 'summary_large_image',
+    },
+  },
+  header: {
+    links: [
+      { id: 'home', label: 'Home' },
+      { id: 'benefits', label: 'Benefits' },
+      { id: 'features', label: 'Features' },
+      { href: '/signup', label: 'Sign Up' },
+    ],
+  },
+  footer: {
+    copyright: `© ${currentYear} MyRoofGenius`,
+    links: [
+      { href: '/', label: 'Home' },
+      { href: '/signup', label: 'Sign Up' },
+      { href: '/login', label: 'Log in' },
+    ],
+  },
+  signup: {
+    title: 'Create your account',
+    text:
+      'Start protecting your roofing decisions with AI-powered tools.',
+    features: [
+      {
+        title: 'Accurate estimates',
+        icon: Building2,
+        description: 'Get AI-generated cost predictions for every project.',
+      },
+      {
+        title: 'Risk analysis',
+        icon: ShieldCheck,
+        description: 'Identify material and code issues before they occur.',
+      },
+      {
+        title: 'Smart planning',
+        icon: BrainCircuit,
+        description: 'Leverage machine learning to optimize your workflow.',
+      },
+    ],
+  },
+  termsUrl: '/terms',
+  privacyUrl: '/privacy',
+}
 
-export const signupText =
-  'Start protecting your roofing decisions with AI-powered tools.';
+export default siteConfig


### PR DESCRIPTION
## Summary
- expand the data config to export a single `siteConfig` object
- define logo, seo, header, footer and signup sections

## Testing
- `npm run lint` *(fails: next not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'stripe')*

------
https://chatgpt.com/codex/tasks/task_e_68570215326c8323ba352bb2b98e3ddd