### PR TITLE
feat: unify legacy components with siteConfig

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,21 +1,25 @@
 import React from 'react';
 import { Facebook, Twitter, Linkedin } from 'lucide-react';
+import siteConfig from '#data/config';
 
 const Footer = () => {
   return (
     <footer className="bg-[#202940] text-gray-200 py-12">
       <div className="max-w-6xl mx-auto px-6 grid md:grid-cols-3 gap-8">
         <div>
-          <h3 className="font-bold text-lg mb-2">MyRoofGenius</h3>
-          <p className="text-sm">Smarter roofing starts here.</p>
+          <h3 className="font-bold text-lg mb-2">{siteConfig.seo.title}</h3>
+          <p className="text-sm">{siteConfig.seo.description}</p>
         </div>
         <div>
           <h4 className="font-semibold mb-2">Quick Links</h4>
           <ul className="space-y-1 text-sm">
-            <li><a href="/" className="hover:text-white">Home</a></li>
-            <li><a href="/marketplace" className="hover:text-white">Marketplace</a></li>
-            <li><a href="/about" className="hover:text-white">About</a></li>
-            <li><a href="/contact" className="hover:text-white">Contact</a></li>
+            {siteConfig.footer.links.map((link) => (
+              <li key={link.href}>
+                <a href={link.href} className="hover:text-white">
+                  {link.label}
+                </a>
+              </li>
+            ))}
           </ul>
         </div>
         <div>
@@ -27,7 +31,7 @@ const Footer = () => {
           </div>
         </div>
       </div>
-      <p className="text-center text-xs mt-8">&copy; {new Date().getFullYear()} MyRoofGenius. All rights reserved.</p>
+      <p className="text-center text-xs mt-8">{siteConfig.footer.copyright}</p>
     </footer>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,16 @@
+import siteConfig from '#data/config';
+
 export default function Header() {
   return (
     <header className="w-full px-6 py-4 flex items-center justify-between border-b">
-      <span className="text-lg font-semibold">MyRoofGenius</span>
+      <span className="text-lg font-semibold">{siteConfig.seo.title}</span>
+      <nav className="space-x-4">
+        {siteConfig.header.links.map((link) => (
+          <a key={link.href || link.id} href={link.href || `/#${link.id}`} className="hover:underline">
+            {link.label}
+          </a>
+        ))}
+      </nav>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- reference the siteConfig object in the older Header/Footer components
- expose SEO text and navigation links from the central config

## Testing
- `pytest -q`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68570407bb0c832392006f6527c171c0