### PR TITLE
Add roof report API and React card

### DIFF
--- a/python-backend/main.py
+++ b/python-backend/main.py
@@ -3,8 +3,18 @@ from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 import stripe
 import httpx
+import importlib.util
+from pathlib import Path
 
 app = FastAPI()
+
+# Dynamically load roof routes to avoid package import issues
+spec = importlib.util.spec_from_file_location(
+    "roof", Path(__file__).resolve().parent / "routes" / "roof.py"
+)
+roof = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(roof)
+app.include_router(roof.router)
 
 app.add_middleware(
     CORSMiddleware,

--- a/python-backend/routes/roof.py
+++ b/python-backend/routes/roof.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/api/roof/report")
+async def roof_report():
+    """Return a placeholder roof report."""
+    return {"report": "All clear"}

--- a/src/components/RoofReportCard.tsx
+++ b/src/components/RoofReportCard.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+
+interface RoofReport {
+  report?: string;
+}
+
+export default function RoofReportCard() {
+  const [data, setData] = useState<RoofReport | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchReport = async () => {
+    setLoading(true);
+    try {
+      const resp = await fetch('/api/roof/report');
+      const json = await resp.json();
+      setData(json);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchReport();
+    const id = setInterval(fetchReport, 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (loading && !data) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      {loading && <div>Refreshing...</div>}
+      <pre data-testid="report">{JSON.stringify(data)}</pre>
+    </div>
+  );
+}

--- a/src/components/__tests__/RoofReportCard.test.tsx
+++ b/src/components/__tests__/RoofReportCard.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import RoofReportCard from '../RoofReportCard';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({ report: 'All clear' })
+    })
+  ) as jest.Mock;
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  (global.fetch as jest.Mock).mockReset();
+});
+
+test('fetches report and refreshes', async () => {
+  render(<RoofReportCard />);
+  expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+  expect(screen.getByTestId('report')).toHaveTextContent('All clear');
+
+  jest.advanceTimersByTime(30000);
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+});

--- a/tests/test_roof_report.py
+++ b/tests/test_roof_report.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+import importlib.util
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock
+
+
+def load_app(monkeypatch):
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    monkeypatch.setenv("SUPABASE_URL", "http://localhost")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "key")
+    monkeypatch.setattr("supabase.create_client", lambda url, key: MagicMock())
+    spec = importlib.util.spec_from_file_location(
+        "python_backend_main", root / "python-backend" / "main.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_roof_report_endpoint(monkeypatch):
+    main = load_app(monkeypatch)
+    client = TestClient(main.app)
+    resp = client.get("/api/roof/report")
+    assert resp.status_code == 200
+    assert resp.json() == {"report": "All clear"}


### PR DESCRIPTION
## Summary
- expose `/api/roof/report` in the FastAPI backend
- poll that endpoint from new `RoofReportCard` component
- add tests for API and component

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857174ed8c08323a25e7972d4b33749