### PR TITLE
Fix CI to use python backend dependencies

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -18,8 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install black
-          pip install -r requirements.txt
-          pip install -r backend/backend/requirements.txt
+          pip install -r python-backend/requirements.txt
       - name: Check formatting
         run: black --check .
       - name: Run tests

--- a/python-backend/requirements.txt
+++ b/python-backend/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn[standard]
 stripe
 httpx
+supabase==2.15.3
+pytest


### PR DESCRIPTION
## Summary
- install deps from `python-backend/requirements.txt`
- include Supabase and PyTest in backend requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571cb6ab648323bfa7ce1444ca5d35