### PR TITLE
Add Jest setup and run tests in CI

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -16,4 +16,5 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run lint
+      - run: npm test
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The backend dependencies include `stripe` for payments and `httpx` for outbound 
 
 ### Running Tests
 
-Frontend tests use Jest via `react-scripts`:
+Frontend tests use Jest:
 ```bash
 npm test
 ```
@@ -38,4 +38,4 @@ pip install -r python-backend/requirements.txt
 pytest
 ```
 
-Continuous integration runs these commands using `.github/workflows/ci.yml` whenever you push or open a pull request.
+Continuous integration runs these commands using the Node and Python workflows under `.github/workflows` whenever you push or open a pull request.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testEnvironment: 'jest-environment-jsdom',
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "next": "14.2.3",
@@ -22,6 +23,10 @@
   "devDependencies": {
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.3",
-    "prettier": "3.3.2"
+    "prettier": "3.3.2",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.4",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest config and setup files
- add test script and testing deps
- run `npm test` in Node CI
- clarify testing section in README

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685733a2db4c832388b1264b5b8e7666