### PR TITLE
Add Vercel rewrites and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,10 @@ pytest
 ```
 
 Continuous integration runs these commands using the Node and Python workflows under `.github/workflows` whenever you push or open a pull request.
+
+## Deployment
+
+1. Create a project on **Vercel** and link this repository.
+2. Add the environment variables listed in [docs/vercel-env.md](docs/vercel-env.md) to the project settings.
+3. Deploying the `main` branch will build the Next.js frontend and the Python backend. The `vercel.json` file rewrites any request matching `/api/*` to the appropriate backend function.
+4. Subsequent pushes to `main` automatically trigger new Vercel deployments.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "rewrites": [{
+    "source": "/api/:path*",
+    "destination": "/api/:path*"
+  }]
+}


### PR DESCRIPTION
## Summary
- add a simple `vercel.json` that rewrites `/api/*`
- document how to deploy the project to Vercel

## Checklist
- [ ] Tests added/updated
- [x] Docs updated
- [ ] I have reviewed security implications

---
### AI-Generation
- [x] This PR **was** generated (fully or partially) by **OpenAI Codex**

------
https://chatgpt.com/codex/tasks/task_e_6857552df6d4832382db3719a82ed649