### PR TITLE
Add RoofReport endpoint and tests

### DIFF
--- a/python-backend/routes/roof.py
+++ b/python-backend/routes/roof.py
@@ -1,8 +1,28 @@
-from fastapi import APIRouter
+from datetime import datetime
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
 
 router = APIRouter()
 
-@router.get("/api/roof/report")
+class RoofReport(BaseModel):
+    status: str
+    lastInspection: datetime
+    damageScore: float
+
+
+async def _build_report() -> RoofReport:
+    """Create a sample roof report."""
+    return RoofReport(
+        status="ok",
+        lastInspection=datetime(2024, 1, 1),
+        damageScore=0.0,
+    )
+
+
+@router.get("/api/roof/report", response_model=RoofReport)
 async def roof_report():
-    """Return a placeholder roof report."""
-    return {"report": "All clear"}
+    """Return a sample roof report."""
+    try:
+        return await _build_report()
+    except Exception:
+        raise HTTPException(status_code=500, detail="Failed to generate roof report")

--- a/tests/test_roof_report.py
+++ b/tests/test_roof_report.py
@@ -25,4 +25,20 @@ def test_roof_report_endpoint(monkeypatch):
     client = TestClient(main.app)
     resp = client.get("/api/roof/report")
     assert resp.status_code == 200
-    assert resp.json() == {"report": "All clear"}
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["damageScore"] == 0.0
+    assert "lastInspection" in data
+
+
+def test_roof_report_failure(monkeypatch):
+    main = load_app(monkeypatch)
+    roof = main.roof
+
+    async def boom():
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(roof, "_build_report", boom)
+    client = TestClient(main.app)
+    resp = client.get("/api/roof/report")
+    assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- implement `RoofReport` model with sample route
- add 500 error handling on failure
- update tests for success and error cases

## Checklist
- [x] Tests added/updated
- [ ] Docs updated
- [x] I have reviewed security implications

---

### AI‑Generation
- [x] This PR **was** generated (fully or partially) by **OpenAI Codex**

------
https://chatgpt.com/codex/tasks/task_e_68585581a1ac8323a304a816cfafa45c