### PR TITLE
Remove console.log from mobile nav

### DIFF
--- a/components/mobile-nav/mobile-nav.tsx
+++ b/components/mobile-nav/mobile-nav.tsx
@@ -70,7 +70,6 @@ export function MobileNavContent(props: MobileNavContentProps) {
   const bgColor = useColorModeValue('whiteAlpha.900', 'blackAlpha.900')
 
   useRouteChanged(onClose)
-  console.log({ isOpen })
   /**
    * Scenario: Menu is open on mobile, and user resizes to desktop/tablet viewport.
    * Result: We'll close the menu

--- a/src/components/mobile-nav/mobile-nav.tsx
+++ b/src/components/mobile-nav/mobile-nav.tsx
@@ -70,7 +70,6 @@ export function MobileNavContent(props: MobileNavContentProps) {
   const bgColor = useColorModeValue('whiteAlpha.900', 'blackAlpha.900')
 
   useRouteChanged(onClose)
-  console.log({ isOpen })
   /**
    * Scenario: Menu is open on mobile, and user resizes to desktop/tablet viewport.
    * Result: We'll close the menu


### PR DESCRIPTION
## Summary
- drop stray console.log from MobileNav component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858665002b48323afc8d47f1c805efb