### PR TITLE
Pin httpx and remove dummy test

### DIFF
--- a/python-backend/requirements.txt
+++ b/python-backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn[standard]
 stripe
-httpx
+httpx<0.28
 supabase==2.15.3
 pytest


### PR DESCRIPTION
## Summary
- pin httpx in backend requirements
- remove unused dummy test file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68586e5a0cd483239fe8b3af14d1db40