### PR TITLE
Fix install failure by replacing deprecated AI package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "autoprefixer": "^10.4.17",
     "postcss": "^8.4.40",
     "framer-motion": "^11.0.0",
-    "@vercel/ai": "^0.17.0",
+    "ai": "^4.3.16",
     "@supabase/supabase-js": "^2.30.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- replace `@vercel/ai` with `ai@^4.3.16` in `package.json`

## Testing
- `npm install`
- `npm test` *(fails: TS6053 File '@tsconfig/next/tsconfig.json' not found)*
- `npm run lint` *(fails: FatalError: file '@tsconfig/next/tsconfig.json' not found)*

------
https://chatgpt.com/codex/tasks/task_e_685870fef7b08323b009bed4bccefd5f