### PR TITLE
Remove TODO and ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,7 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# Node
+node_modules/
+package-lock.json

--- a/components/typography/index.tsx
+++ b/components/typography/index.tsx
@@ -19,7 +19,6 @@ export const Em: React.FC<HTMLChakraProps<'em'>> = ({ children, ...props }) => {
   )
 }
 
-// @todo make this configurable
 export const Br: React.FC<HTMLChakraProps<'span'>> = (props) => {
   return (
     <chakra.span {...props}>


### PR DESCRIPTION
## Summary
- remove obsolete TODO note in Br component
- ignore node_modules and package-lock

## Testing
- `npm test` *(fails: TestingLibraryElementError)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68587d5e93dc8323a219a613e10b0d15