### PR TITLE
Remove deprecated Next.js experimental option

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,9 +3,7 @@ const path = require('path');
 
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    appDir: true,
-  },
+  appDir: true,
   webpack(config) {
     config.resolve.alias['#components'] = path.join(__dirname, 'components');
     config.resolve.alias['#data'] = path.join(__dirname, 'data');


### PR DESCRIPTION
## Summary
- enable stable `appDir` and remove deprecated `experimental.appDir`

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated
- [ ] I have reviewed security implications

---

### AI‑Generation
- [x] This PR **was** generated (fully or partially) by **OpenAI Codex**

------
https://chatgpt.com/codex/tasks/task_e_685880531e4c83239edb89dc28a1e168