### PR TITLE
Remove deprecated appDir config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,6 @@ const path = require('path');
 
 const nextConfig = {
   reactStrictMode: true,
-  appDir: true,
   webpack(config) {
     config.resolve.alias['#components'] = path.join(__dirname, 'components');
     config.resolve.alias['#data'] = path.join(__dirname, 'data');


### PR DESCRIPTION
## Summary
- remove `appDir` from Next.js config since App Router is now default

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated
- [ ] I have reviewed security implications

---

### AI‑Generation
- [x] This PR **was** generated (fully or partially) by **OpenAI Codex**
- [ ] This PR **was NOT** generated by Codex

------
https://chatgpt.com/codex/tasks/task_e_68589c5ceee48323b64007f4b1af5278