### PR TITLE
feat: add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Stage 1: build Next.js frontend
+FROM node:20-alpine AS frontend
+WORKDIR /app
+COPY package.json ./
+# install dependencies
+RUN npm install
+# copy source
+COPY . .
+RUN npm run build
+
+# Stage 2: run FastAPI backend
+FROM python:3.11-slim as backend
+WORKDIR /app
+
+# install python dependencies
+COPY python-backend/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# copy backend source
+COPY python-backend ./python-backend
+
+# copy built frontend from previous stage
+COPY --from=frontend /app/.next ./frontend/.next
+COPY --from=frontend /app/public ./frontend/public
+COPY --from=frontend /app/next.config.js ./frontend/next.config.js
+
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--app-dir", "python-backend", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ Continuous integration runs these commands using the Node and Python workflows u
 2. Add the variables from `.env.example` as Vercel environment variables. Each is explained in [docs/vercel-env.md](docs/vercel-env.md).
 3. Deploying the `main` branch will build the Next.js frontend and the Python backend. The `vercel.json` file rewrites any request matching `/api/*` to the appropriate backend function.
 4. Subsequent pushes to `main` automatically trigger new Vercel deployments.
+
+### Docker
+
+Build and run the production container locally:
+
+```bash
+docker build -t myroofgenius-app .
+docker run -p 8000:8000 myroofgenius-app
+```
+
+The image starts Uvicorn for the FastAPI backend and includes the compiled Next.js frontend.


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile to build Next.js frontend and run FastAPI backend
- document Docker build and run steps in README

## Testing
- `npm test` *(fails: TestingLibraryElementError)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6858a510d0508323ba86b938eac9bb16