### PR TITLE
docs: clarify bootstrap script status

### DIFF
--- a/README-CODEX-SETUP.md
+++ b/README-CODEX-SETUP.md
@@ -26,5 +26,9 @@ npm i -g @openai/codex-cli
 codex generate
 ```
 
+> **Note**
+> The helper script `scripts/bootstrap_codex.sh` used for Codex CLI setup is
+> obsolete and kept only for reference. Run `codex generate` directly instead.
+
 ## 5. Cross‑Repo Dependency
 Relies on **brainops‑langgraph‑orchestrator** API; deploy orchestrator first.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,8 @@ docker run -p 8000:8000 myroofgenius-app
 ```
 
 The image starts Uvicorn for the FastAPI backend and includes the compiled Next.js frontend.
+
+### Deprecated Bootstrap Script
+The helper script `scripts/bootstrap_codex.sh` previously bootstrapped the
+Codex CLI. The CLI has been removed, so this script is obsolete and kept only
+for reference.

--- a/scripts/bootstrap_codex.sh
+++ b/scripts/bootstrap_codex.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
-# Deprecated: Codex CLI has been removed. This script is no longer needed.
+# OBSOLETE: This script was previously used to bootstrap the Codex CLI
+# environment. The CLI has been removed and this file is kept only for
+# historical reference.


### PR DESCRIPTION
## Summary
- mark `scripts/bootstrap_codex.sh` as obsolete
- document the deprecated bootstrap script in READMEs

## Testing
- `npm test --silent` *(fails: TestingLibraryElementError)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a70a77e88323a46320acfc1ea2a1