### PR TITLE
chore: use logging instead of prints

### DIFF
--- a/api/api/webhook.py
+++ b/api/api/webhook.py
@@ -4,7 +4,8 @@ import stripe
 import logging
 from supabase import create_client
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.INFO,
+                    format="%(levelname)s:%(name)s:%(message)s")
 logger = logging.getLogger(__name__)
 
 stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
@@ -28,6 +29,8 @@ async def handler(request):
 
     if event["type"] == "checkout.session.completed":
         session = event["data"]["object"]
+        logger.info("Processing checkout.session.completed for session %s",
+                    session["id"])
         try:
             supabase.table("orders").insert({
                 "user_id": session.get("metadata", {}).get("user_id"),

--- a/python-backend/main.py
+++ b/python-backend/main.py
@@ -9,7 +9,8 @@ from pathlib import Path
 import sys
 import types
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.INFO,
+                    format="%(levelname)s:%(name)s:%(message)s")
 logger = logging.getLogger(__name__)
 try:
     from supabase import create_client


### PR DESCRIPTION
## Summary
- configure basic Python logging
- log webhook events and errors in `api/webhook`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a809a4148323a7562ced98fd2216