### PR TITLE
docs: clarify bootstrap script status

### DIFF
--- a/README-CODEX-SETUP.md
+++ b/README-CODEX-SETUP.md
@@ -28,7 +28,8 @@ codex generate
 
 > **Note**
 > The helper script `scripts/bootstrap_codex.sh` used for Codex CLI setup is
-> obsolete and kept only for reference. Run `codex generate` directly instead.
+> obsolete and now performs no actions. It remains for reference only. Run
+> `codex generate` directly instead.
 
 ## 5. Cross‑Repo Dependency
 Relies on **brainops‑langgraph‑orchestrator** API; deploy orchestrator first.

--- a/README.md
+++ b/README.md
@@ -62,5 +62,5 @@ the Python requirements and launches Uvicorn with the built assets included.
 
 ### Deprecated Bootstrap Script
 The helper script `scripts/bootstrap_codex.sh` previously bootstrapped the
-Codex CLI. The CLI has been removed, so this script is obsolete and kept only
-for reference.
+Codex CLI. The CLI has been removed, so this script does nothing and is kept
+only for historical reference. Feel free to delete it locally.

--- a/scripts/bootstrap_codex.sh
+++ b/scripts/bootstrap_codex.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# OBSOLETE: This script was previously used to bootstrap the Codex CLI
-# environment. The CLI has been removed and this file is kept only for
-# historical reference.
+# OBSOLETE: This script previously bootstrapped the Codex CLI environment.
+# The CLI has been removed, so this file remains only for historical
+# reference and performs no actions.


### PR DESCRIPTION
## Summary
- explain obsolete Codex bootstrap script in READMEs
- improve comment in `scripts/bootstrap_codex.sh`

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b2d0947083239a86120297e1e37c