### PR TITLE
Add environment variable validation

### DIFF
--- a/api/api/checkout.py
+++ b/api/api/checkout.py
@@ -1,6 +1,20 @@
-import os, json, stripe
+import os
+import json
+import stripe
+import logging
 
-stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
+logger = logging.getLogger(__name__)
+
+
+def _required_env(var_name: str) -> str:
+    value = os.getenv(var_name)
+    if not value:
+        logger.error("Missing required environment variable: %s", var_name)
+        raise RuntimeError(f"{var_name} environment variable is required")
+    return value
+
+
+stripe.api_key = _required_env("STRIPE_SECRET_KEY")
 
 
 async def handler(request):

--- a/api/api/webhook.py
+++ b/api/api/webhook.py
@@ -7,11 +7,19 @@ from supabase import create_client
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
 logger = logging.getLogger(__name__)
 
-stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
-WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET")
 
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+def _required_env(var_name: str) -> str:
+    value = os.getenv(var_name)
+    if not value:
+        logger.error("Missing required environment variable: %s", var_name)
+        raise RuntimeError(f"{var_name} environment variable is required")
+    return value
+
+stripe.api_key = _required_env("STRIPE_SECRET_KEY")
+WEBHOOK_SECRET = _required_env("STRIPE_WEBHOOK_SECRET")
+
+SUPABASE_URL = _required_env("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY = _required_env("SUPABASE_SERVICE_ROLE_KEY")
 
 supabase = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 

--- a/api/subscribe.py
+++ b/api/subscribe.py
@@ -1,7 +1,20 @@
-import os, json
+import os
+import json
 import httpx
+import logging
 
-CONVERTKIT_API_KEY = os.getenv("CONVERTKIT_API_KEY")
+logger = logging.getLogger(__name__)
+
+
+def _required_env(var_name: str) -> str:
+    value = os.getenv(var_name)
+    if not value:
+        logger.error("Missing required environment variable: %s", var_name)
+        raise RuntimeError(f"{var_name} environment variable is required")
+    return value
+
+
+CONVERTKIT_API_KEY = _required_env("CONVERTKIT_API_KEY")
 CONVERTKIT_FORM_ID = os.getenv("CONVERTKIT_FORM_ID", "64392d9bef")
 
 

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -10,6 +10,15 @@ import types
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
 logger = logging.getLogger(__name__)
+
+
+def _required_env(var_name: str) -> str:
+    """Return environment variable or raise a RuntimeError if missing."""
+    value = os.getenv(var_name)
+    if not value:
+        logger.error("Missing required environment variable: %s", var_name)
+        raise RuntimeError(f"{var_name} environment variable is required")
+    return value
 try:
     from supabase import create_client
 except ModuleNotFoundError:  # Allow tests without package
@@ -33,15 +42,16 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Initialize Stripe
-stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
-stripe_webhook_secret = os.getenv("STRIPE_WEBHOOK_SECRET")
 
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+# Initialize Stripe
+stripe.api_key = _required_env("STRIPE_SECRET_KEY")
+stripe_webhook_secret = _required_env("STRIPE_WEBHOOK_SECRET")
+
+SUPABASE_URL = _required_env("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY = _required_env("SUPABASE_SERVICE_ROLE_KEY")
 supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
-CONVERTKIT_API_KEY = os.getenv("CONVERTKIT_API_KEY")
+CONVERTKIT_API_KEY = _required_env("CONVERTKIT_API_KEY")
 CONVERTKIT_FORM_ID = os.getenv("CONVERTKIT_FORM_ID", "64392d9bef")
 
 

--- a/scripts/codegen.py
+++ b/scripts/codegen.py
@@ -7,8 +7,20 @@ and writes the result to stdout or a file.
 import argparse
 import os
 import openai
+import logging
 
-openai.api_key = os.environ.get("OPENAI_API_KEY")
+logger = logging.getLogger(__name__)
+
+
+def _required_env(var_name: str) -> str:
+    value = os.environ.get(var_name)
+    if not value:
+        logger.error("Missing required environment variable: %s", var_name)
+        raise RuntimeError(f"{var_name} environment variable is required")
+    return value
+
+
+openai.api_key = _required_env("OPENAI_API_KEY")
 
 
 def main() -> None:

--- a/tests/test_env_vars.py
+++ b/tests/test_env_vars.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+import sys
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def import_backend(monkeypatch):
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+    import stripe_stub
+    sys.modules["stripe"] = stripe_stub
+    monkeypatch.setattr("supabase.create_client", lambda url, key: MagicMock())
+    package = ModuleType("python_backend")
+    package.__path__ = [str(ROOT / "python_backend")]
+    sys.modules["python_backend"] = package
+    module = ModuleType("python_backend.main")
+    module.__package__ = "python_backend"
+    sys.modules["python_backend.main"] = module
+    path = ROOT / "python_backend" / "main.py"
+    code = path.read_text()
+    exec(compile(code, str(path), "exec"), module.__dict__)
+    return module
+
+
+REQUIRED_VARS = {
+    "STRIPE_SECRET_KEY": "sk",
+    "STRIPE_WEBHOOK_SECRET": "wh",
+    "SUPABASE_URL": "http://localhost",
+    "SUPABASE_SERVICE_ROLE_KEY": "key",
+    "CONVERTKIT_API_KEY": "ck",
+}
+
+
+@pytest.mark.parametrize("missing", list(REQUIRED_VARS.keys()))
+def test_missing_env_var_raises(monkeypatch, missing):
+    for k, v in REQUIRED_VARS.items():
+        if k != missing:
+            monkeypatch.setenv(k, v)
+    monkeypatch.delenv(missing, raising=False)
+    with pytest.raises(RuntimeError):
+        import_backend(monkeypatch)
+
+
+def test_backend_imports_with_all_vars(monkeypatch):
+    for k, v in REQUIRED_VARS.items():
+        monkeypatch.setenv(k, v)
+    mod = import_backend(monkeypatch)
+    assert hasattr(mod, "app")

--- a/tests/test_roof_report.py
+++ b/tests/test_roof_report.py
@@ -11,6 +11,9 @@ def load_app(monkeypatch):
         sys.path.insert(0, str(root))
     import stripe_stub
     sys.modules["stripe"] = stripe_stub
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk")
+    monkeypatch.setenv("STRIPE_WEBHOOK_SECRET", "wh")
+    monkeypatch.setenv("CONVERTKIT_API_KEY", "ck")
     monkeypatch.setenv("SUPABASE_URL", "http://localhost")
     monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "key")
     monkeypatch.setattr("supabase.create_client", lambda url, key: MagicMock())

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -8,6 +8,8 @@ import httpx
 
 
 def load_app(monkeypatch):
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk")
+    monkeypatch.setenv("STRIPE_WEBHOOK_SECRET", "wh")
     monkeypatch.setenv("CONVERTKIT_API_KEY", "key")
     monkeypatch.setenv("CONVERTKIT_FORM_ID", "form")
     monkeypatch.setenv("SUPABASE_URL", "http://localhost")


### PR DESCRIPTION
## Summary
- ensure required environment variables are present in python backend and API handlers
- log missing variable errors and raise `RuntimeError`
- update test helpers to set env vars
- add new tests for missing variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e33552088323b6b1bb48d703cc78