### PR TITLE
Remove NextPage typings from pages

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,7 +4,6 @@ import { Link } from '@saas-ui/react'
 import { BackgroundGradient } from 'components/gradients/background-gradient'
 import { PageTransition } from 'components/motion/page-transition'
 import { Section } from 'components/section'
-import { NextPage } from 'next'
 import { FaGithub, FaGoogle } from 'react-icons/fa'
 
 const providers = {
@@ -19,7 +18,7 @@ const providers = {
   },
 }
 
-const Login: NextPage = () => {
+export default function Page() {
   return (
     <Section height="calc(100vh - 200px)" innerWidth="container.sm">
       <BackgroundGradient zIndex="-1" />
@@ -36,5 +35,3 @@ const Login: NextPage = () => {
     </Section>
   )
 }
-
-export default Login

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,7 +1,6 @@
 import { Box, Center, Stack, Text } from '@chakra-ui/react'
 import { Auth } from '@saas-ui/auth'
 import { Link } from '@saas-ui/react'
-import { NextPage } from 'next'
 import NextLink from 'next/link'
 import { FaGithub, FaGoogle } from 'react-icons/fa'
 
@@ -23,7 +22,7 @@ const providers = {
   },
 }
 
-const Login: NextPage = () => {
+export default function Page() {
   return (
     <Section height="100vh" innerWidth="container.xl">
       <BackgroundGradient
@@ -96,4 +95,3 @@ const Login: NextPage = () => {
   )
 }
 
-export default Login

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -17,7 +17,7 @@ import {
   useClipboard,
 } from '@chakra-ui/react'
 import { Br, Link } from '@saas-ui/react'
-import type { Metadata, NextPage } from 'next'
+import type { Metadata } from 'next'
 import {
   FiArrowRight,
   FiBox,
@@ -69,7 +69,7 @@ export const meta: Metadata = {
   description: 'Intelligent systems that protect every commercial roofing decision.',
 }
 
-const Home: NextPage = () => {
+export default function Page() {
   return (
     <Box>
       <HeroSection />
@@ -408,4 +408,3 @@ const FaqSection = () => {
   return <Faq {...faq} />
 }
 
-export default Home


### PR DESCRIPTION
## Summary
- remove `NextPage` imports
- convert page components to plain functions named `Page`

## Testing
- `npm test`
- `npx next lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6858ebcdae7483238c73f98086256a97