### PR TITLE
Fetch roof reports from Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Run it locally with Uvicorn:
 ```
 The backend dependencies include `stripe` for payments and `httpx` for outbound HTTP calls.
 
+#### Roof Report API
+
+`GET /api/roof/report` returns the latest roof condition metrics from Supabase.
+Ensure `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are set.
+
 ### Running Tests
 
 Frontend tests use Jest:


### PR DESCRIPTION
## Summary
- fetch the latest roof report from Supabase in `python_backend`
- describe the new `/api/roof/report` endpoint in the README
- adapt tests for the updated report logic

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859683c278083238ac6a56df5aa55fb