### PR TITLE
Fix App.js imports and routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,26 +1,25 @@
-impor, useEffectt React, { useState } from 'react';
+import React, { useState, useEffect, lazy, Suspense } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
-import Home from './pages/Home';
-// Lazy‑load other pages (placeholders for now)
-const Marketplace = React.lazy(() => import('./pages/Marketplace'));
-const Product = React.lazy(() => import('./pages/Product'));
+import * as Sentry from '@sentry/react';
+
 import Header from './components/Header';
 import Footer from './components/Footer';
-import * as Sentry from '@sentry/react';
+
+const Home = lazy(() => import('./pages/Home'));
+const Marketplace = lazy(() => import('./pages/Marketplace'));
+const Product = lazy(() => import('./pages/Product'));
+const Blog = lazy(() => import('./pages/Blog'));
+const Account = lazy(() => import('./pages/Account'));
+const Success = lazy(() => import('./pages/Success'));
+const Cancel = lazy(() => import('./pages/Cancel'));
+
+// Initialize Sentry for error tracking
 Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  
+  dsn: process.env.REACT_APP_SENTRY_DSN,
 });
 
-const Blog = React.lazy(() => import('./pages/Blog'));
-const Account = React.lazy(() => import('./pages/Account'));
-const Success = React.lazy(() => import('./pages/Success'));
-const Cancel = React.lazy(() => import('./pages/Cancel'));
-
-
-const SubscribeForm = () => {
+function SubscribeForm() {
   const [email, setEmail] = useState('');
-  
   const [status, setStatus] = useState(null);
 
   const handleSubmit = async (e) => {
@@ -43,9 +42,7 @@ const SubscribeForm = () => {
     }
   };
 
-  ret
-      <Header />
-urn (
+  return (
     <form onSubmit={handleSubmit} style={{ marginTop: '1rem' }}>
       <input
         type="email"
@@ -63,46 +60,53 @@ urn (
       {status === 'error' && <p>Something went wrong.</p>}
     </form>
   );
-};
+}
 
-function 
-  A
-    useEffect(() => {
-    if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID) {
+export default function App() {
+  useEffect(() => {
+    const gaId = process.env.REACT_APP_GA_MEASUREMENT_ID;
+    if (typeof window !== 'undefined' && gaId) {
       window.dataLayer = window.dataLayer || [];
-      function gtag(){window.dataLayer.push(arguments);}
+      function gtag() {
+        window.dataLayer.push(arguments);
+      }
       gtag('js', new Date());
-      gtag('config', process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID);
+      gtag('config', gaId);
       const script = document.createElement('script');
       script.async = true;
-      script.src = `https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}`;
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`;
       document.head.appendChild(script);
     }
   }, []);
-pp() {
+
   return (
     <Router>
+      <Header />
       <nav style={{ padding: '1rem', background: '#f5f5f5' }}>
-        <Link to="/" style={{ marginRight: '1rem' }}>Home</Link>
-        <Link to="/marketplace" style={{ marginRight: '1rem' }}>Marketplace</Link>
-        <Link to="/blog" style={{ marginRight: '1rem' }}>Blog</Link>
+        <Link to="/" style={{ marginRight: '1rem' }}>
+          Home
+        </Link>
+        <Link to="/marketplace" style={{ marginRight: '1rem' }}>
+          Marketplace
+        </Link>
+        <Link to="/blog" style={{ marginRight: '1rem' }}>
+          Blog
+        </Link>
         <Link to="/account">Account</Link>
       </nav>
-
-      <React.Suspense fallback={<p>Loading…</p>}>
+      <Suspense fallback={<p>Loading…</p>}>
         <Routes>
           <Route path="/" element={<><Home /><SubscribeForm /></>} />
           <Route path="/marketplace" element={<Marketplace />} />
           <Route path="/product/:id" element={<Product />} />
           <Route path="/blog" element={<Blog />} />
           <Route path="/account" element={<Account />} />
-                  <Route path="/success" element={<Success />} />
+          <Route path="/success" element={<Success />} />
           <Route path="/cancel" element={<Cancel />} />
         </Routes>
-      </React.Suspense>
-        </Router>
-    <Footer />
+      </Suspense>
+      <Footer />
+    </Router>
   );
 }
 
-export default App;


### PR DESCRIPTION
## Summary
- clean up App.js imports and component structure
- ensure lazy-loaded pages render correctly with router
- retain GA tracking snippet and Sentry initialization

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0fdacf9c8323ad757f0fcb3ee624