### PR TITLE
Refactor pages to use JSON content

### DIFF
--- a/api/api/checkout.py
+++ b/api/api/checkout.py
@@ -15,7 +15,7 @@ async def handler(request):
     if not price_id:
         return {"statusCode": 400, "body": json.dumps({"error": "price_id required"})}
 
-    domain = body.get("domain", os.getenv("CHECKOUT_DOMAIN", "https://myroofgenius.com"))
+    domain = body.get("domain", os.getenv("CHECKOUT_DOMAIN", "REPLACE_ME"))
 
     try:
         session = stripe.checkout.Session.create(

--- a/backend/main.py
+++ b/backend/main.py
@@ -52,7 +52,7 @@ async def checkout(request: Request):
     price_id = data.get("price_id")
     if not price_id:
         raise HTTPException(status_code=400, detail="price_id required")
-    domain = data.get("domain", os.getenv("CHECKOUT_DOMAIN", "https://myroofgenius.com"))
+    domain = data.get("domain", os.getenv("CHECKOUT_DOMAIN", "REPLACE_ME"))
     session = stripe.checkout.Session.create(
         mode="payment",
         line_items=[{"price": price_id, "quantity": 1}],

--- a/data/account.json
+++ b/data/account.json
@@ -1,0 +1,6 @@
+{
+  "title": "Your Account",
+  "signIn": "Sign in with GitHub",
+  "ordersHeadline": "Your Orders",
+  "noOrders": "No orders yet."
+}

--- a/data/blog.json
+++ b/data/blog.json
@@ -1,0 +1,4 @@
+{
+  "title": "Blog",
+  "noPosts": "No posts yet."
+}

--- a/data/cancel.json
+++ b/data/cancel.json
@@ -1,0 +1,5 @@
+{
+  "title": "Payment canceled",
+  "text": "REPLACE_ME Your payment was canceled or failed. You can try again anytime.",
+  "linkText": "Back to Marketplace"
+}

--- a/data/home.json
+++ b/data/home.json
@@ -1,0 +1,4 @@
+{
+  "headline": "REPLACE_ME Welcome to MyRoofGenius",
+  "subline": "REPLACE_ME Your one-stop marketplace for roofing knowledge & tools."
+}

--- a/data/marketplace.json
+++ b/data/marketplace.json
@@ -1,0 +1,4 @@
+{
+  "title": "Marketplace",
+  "viewButton": "View"
+}

--- a/data/product.json
+++ b/data/product.json
@@ -1,0 +1,5 @@
+{
+  "loading": "Loading\u2026",
+  "notFound": "Product not found.",
+  "buyButton": "Buy Now"
+}

--- a/data/success.json
+++ b/data/success.json
@@ -1,0 +1,5 @@
+{
+  "title": "Thank you for your purchase!",
+  "text": "REPLACE_ME Your order was successful. A confirmation email is on its way.",
+  "linkText": "Go to your account"
+}

--- a/src/pages/Account.js
+++ b/src/pages/Account.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../supabaseClient';
+import content from '../../data/account.json';
 
 const Account = () => {
   const [user, setUser] = useState(null);
@@ -33,16 +34,16 @@ const Account = () => {
   if (!user)
     return (
       <div style={{ padding: '2rem' }}>
-        <h1>Your Account</h1>
-        <button onClick={handleLogin}>Sign in with GitHub</button>
+        <h1>{content.title}</h1>
+        <button onClick={handleLogin}>{content.signIn}</button>
       </div>
     );
 
   return (
     <div style={{ padding: '2rem' }}>
-      <h1>Your Orders</h1>
+      <h1>{content.ordersHeadline}</h1>
       {orders.length === 0 ? (
-        <p>No orders yet.</p>
+        <p>{content.noOrders}</p>
       ) : (
         <ul>
           {orders.map((o) => (

--- a/src/pages/Blog.js
+++ b/src/pages/Blog.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../supabaseClient';
+import content from '../../data/blog.json';
 
 const Blog = () => {
   const [posts, setPosts] = useState([]);
@@ -17,9 +18,9 @@ const Blog = () => {
 
   return (
     <div style={{ padding: '2rem' }}>
-      <h1>Blog</h1>
+      <h1>{content.title}</h1>
       {posts.length === 0 ? (
-        <p>No posts yet.</p>
+        <p>{content.noPosts}</p>
       ) : (
         posts.map((p) => (
           <article key={p.id} style={{ marginBottom: '2rem' }}>

--- a/src/pages/Cancel.js
+++ b/src/pages/Cancel.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import content from '../../data/cancel.json';
 
 const Cancel = () => (
   <div style={{ padding: '2rem' }}>
-    <h1>Payment canceled</h1>
-    <p>Your payment was canceled or failed. You can try again anytime.</p>
-    <Link to="/marketplace">Back to Marketplace</Link>
+    <h1>{content.title}</h1>
+    <p>{content.text}</p>
+    <Link to="/marketplace">{content.linkText}</Link>
   </div>
 );
 

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import content from '../../data/home.json';
 
 const Home = () => (
   <div style={{ padding: '2rem' }}>
-    <h1>Welcome to MyRoofGenius</h1>
-    <p>Your one‑stop marketplace for roofing knowledge & tools.</p>
+    <h1>{content.headline}</h1>
+    <p>{content.subline}</p>
   </div>
 );
 

--- a/src/pages/Marketplace.js
+++ b/src/pages/Marketplace.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import supabase from '../supabaseClient';
+import { supabase } from '../supabaseClient';
+import content from '../../data/marketplace.json';
 
 const Marketplace = () => {
   const [products, setProducts] = useState([]);
@@ -14,7 +15,7 @@ const Marketplace = () => {
 
   return (
     <div className="max-w-6xl mx-auto px-6 py-16">
-      <h1 className="text-3xl font-bold mb-8 text-[#202940]">Marketplace</h1>
+      <h1 className="text-3xl font-bold mb-8 text-[#202940]">{content.title}</h1>
       <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
         {products.map((p) => (
           <div key={p.id} className="bg-white rounded-lg shadow hover:shadow-lg transition">
@@ -24,7 +25,7 @@ const Marketplace = () => {
               <p className="text-sm text-gray-600 mb-2">{p.description}</p>
               <p className="font-bold text-[#2366d1] mb-4">${p.price}</p>
               <a href={`/product/${p.id}`} className="bg-[#2366d1] hover:bg-[#1e59b8] text-white py-2 px-4 rounded w-full inline-block text-center">
-                View
+                {content.viewButton}
               </a>
             </div>
           </div>

--- a/src/pages/Product.js
+++ b/src/pages/Product.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
+import content from '../../data/product.json';
 
 const Product = () => {
   const { id } = useParams();
@@ -33,15 +34,15 @@ const Product = () => {
     if (data.url) window.location.href = data.url;
   };
 
-  if (loading) return <p style={{ padding: '2rem' }}>Loading…</p>;
-  if (!product) return <p style={{ padding: '2rem' }}>Product not found.</p>;
+  if (loading) return <p style={{ padding: '2rem' }}>{content.loading}</p>;
+  if (!product) return <p style={{ padding: '2rem' }}>{content.notFound}</p>;
 
   return (
     <div style={{ padding: '2rem' }}>
       <h1>{product.name}</h1>
       <p>{product.description}</p>
       <p>${product.price}</p>
-      <button onClick={handleBuy}>Buy Now</button>
+      <button onClick={handleBuy}>{content.buyButton}</button>
     </div>
   );
 };

--- a/src/pages/Success.js
+++ b/src/pages/Success.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import content from '../../data/success.json';
 
 const Success = () => (
   <div style={{ padding: '2rem' }}>
-    <h1>Thank you for your purchase!</h1>
-    <p>Your order was successful. A confirmation email is on its way.</p>
-    <Link to="/account">Go to your account</Link>
+    <h1>{content.title}</h1>
+    <p>{content.text}</p>
+    <Link to="/account">{content.linkText}</Link>
   </div>
 );
 


### PR DESCRIPTION
## Summary
- centralize page text inside a new `data` folder
- refactor pages to read headlines and copy from JSON
- mark production domain in API handlers with `REPLACE_ME`

## Testing
- `pip install -r python-backend/python-backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a12facc248323a310bbd6df54c7e7