### PR TITLE
Add About and Contact pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,17 @@
+export default function About() {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>About MyRoofGenius</h1>
+      <p>
+        MyRoofGenius designs AI-native systems for commercial roofing professionals.
+        Our tools reinforce your expertise by providing verified data and preventing
+        costly mistakes.
+      </p>
+      <h2 style={{ marginTop: '1rem' }}>Mission</h2>
+      <p>
+        We build protective intelligence that helps professionals make high-stakes
+        decisions with confidence and accuracy.
+      </p>
+    </div>
+  )
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,48 @@
+'use client'
+import { useState } from 'react'
+
+export default function Contact() {
+  const [form, setForm] = useState({ name: '', email: '', message: '' })
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    alert('Message sent')
+  }
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Contact Us</h1>
+      <form onSubmit={handleSubmit} style={{ maxWidth: '400px', display: 'grid', gap: '0.5rem' }}>
+        <input
+          type="text"
+          name="name"
+          placeholder="Name"
+          value={form.name}
+          onChange={handleChange}
+          required
+        />
+        <input
+          type="email"
+          name="email"
+          placeholder="Email"
+          value={form.email}
+          onChange={handleChange}
+          required
+        />
+        <textarea
+          name="message"
+          placeholder="Message"
+          rows={4}
+          value={form.message}
+          onChange={handleChange}
+          required
+        />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import { ColorModeScript, theme } from '@chakra-ui/react'
 
 import { Provider } from './provider'
+import Header from '../components/Header'
+import Footer from '../components/Footer'
 
 export default function Layout(props: { children: React.ReactNode }) {
   const colorMode = theme.config.initialColorMode
@@ -29,7 +31,9 @@ export default function Layout(props: { children: React.ReactNode }) {
       </head>
       <body className={`chakra-ui-${colorMode}`}>
         <ColorModeScript initialColorMode={colorMode} />
+        <Header />
         <Provider>{props.children}</Provider>
+        <Footer />
       </body>
     </html>
   )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,19 @@
+import Link from 'next/link'
+import siteConfig from '../data/config'
+
 export default function Header() {
   return (
     <header className="w-full px-6 py-4 flex items-center justify-between border-b">
-      <span className="text-lg font-semibold">MyRoofGenius</span>
+      <span className="text-lg font-semibold">
+        <Link href="/">{siteConfig.name}</Link>
+      </span>
+      <nav className="space-x-4 text-sm">
+        {siteConfig.header.links.map(({ id, label, href }) => (
+          <Link key={id} href={href} className="hover:underline">
+            {label}
+          </Link>
+        ))}
+      </nav>
     </header>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- add `About` page with company overview
- add `Contact` page with simple form
- update `Header` component to render nav links
- include `Header` and `Footer` in the root layout

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_685abee994848323ba3f84d5df321c33