### PR TITLE
Add Claude task webhook endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,15 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=public-anon-key
 NEXT_PUBLIC_SITE_URL=https://myroofgenius.com
 MAKE_API_KEY=
 CLICKUP_API_KEY=
+
+# Base URL for the FastAPI backend (used by the React app)
+NEXT_PUBLIC_API_BASE_URL=
+
+# Optional Make.com webhook URL for Claude tasks
+MAKE_WEBHOOK_URL=
+
+# Claude API key for direct requests
+CLAUDE_API_KEY=
+
+# Secret token protecting the Claude task trigger endpoint
+CLAUDE_TRIGGER_TOKEN=

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -23,7 +23,8 @@ export default function Product() {
     if (!product) return
     const user = (await supabase.auth.getUser()).data?.user
 
-    const res = await fetch('/api/checkout', {
+    const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || ''
+    const res = await fetch(`${apiBase}/api/checkout`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/src/components/ClaudeTestConsole.jsx
+++ b/src/components/ClaudeTestConsole.jsx
@@ -12,10 +12,11 @@ export default function ClaudeTestConsole() {
   const [prompt, setPrompt] = useState('');
   const [role, setRole] = useState('contractor');
   const [response, setResponse] = useState('');
+  const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || '';
 
   const sendPrompt = async () => {
     try {
-      const res = await fetch(`/webhooks/claude-task-trigger/${role}`, {
+      const res = await fetch(`${apiBase}/webhooks/claude-task-trigger/${role}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary
- secure FastAPI with Claude task trigger route
- allow Make.com forwarding or direct Claude API calls
- expose new environment variables
- support API base URL in frontend

## Testing
- `npm install`
- `npm run lint` *(fails: next not found when not installed)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ac8afa4908323858e6810629dd4d2