### PR TITLE
Add testimonials and dark theme tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,15 +2,19 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Gemini-inspired dark palette */
+/* Futuristic dark theme colors */
 :root {
-  --bg: #0d1117;
-  --fg: #f8fafc;
-  --accent: #3b82f6;
+  --bg: #121212;
+  --bg-elevated: #1c1c1e;
+  --fg: #f2f2f7;
+  --fg-secondary: #8e8e93;
+  --accent: #5e5ce6;
 }
 
 .light {
   --bg: #ffffff;
+  --bg-elevated: #f8f8f8;
   --fg: #0f172a;
-  --accent: #3b82f6;
+  --fg-secondary: #6b7280;
+  --accent: #5e5ce6;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useState } from 'react'
 import Button from '../components/ui/Button'
+import Testimonial from '../components/Testimonial'
 
 export default function Home() {
   const [email, setEmail] = useState('')
@@ -193,6 +194,21 @@ export default function Home() {
               <p className="text-gray-600">Customer satisfaction rate</p>
             </div>
           </div>
+        </div>
+      </section>
+
+      {/* Testimonials */}
+      <section className="py-16 bg-background">
+        <div className="max-w-4xl mx-auto px-4 grid md:grid-cols-3 gap-6">
+          <Testimonial
+            quote="MyRoofGenius helped us uncover hidden costs and win larger contracts."
+            author="Alex R." title="Denver Contractor" />
+          <Testimonial
+            quote="The templates saved our team countless hours each week."
+            author="Jasmine T." title="Operations Manager" />
+          <Testimonial
+            quote="Best investment we've made for our roofing business." 
+            author="Mike B." title="Founder, Summit Roofing" />
         </div>
       </section>
 

--- a/components/Testimonial.tsx
+++ b/components/Testimonial.tsx
@@ -1,0 +1,20 @@
+'use client'
+import Card from './ui/Card'
+
+interface TestimonialProps {
+  quote: string
+  author: string
+  title?: string
+}
+
+export default function Testimonial({ quote, author, title }: TestimonialProps) {
+  return (
+    <Card className="text-center space-y-4">
+      <p className="text-foreground-secondary text-sm">"{quote}"</p>
+      <div>
+        <p className="font-semibold text-foreground">{author}</p>
+        {title && <p className="text-xs text-foreground-secondary">{title}</p>}
+      </div>
+    </Card>
+  )
+}

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { motion } from 'framer-motion'
+import clsx from 'clsx'
+
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  hover?: boolean
+}
+
+export default function Card({ hover = true, className, ...props }: CardProps) {
+  const motionProps = hover
+    ? { whileHover: { y: -4, boxShadow: '0 4px 20px rgba(0,0,0,0.25)' } }
+    : {}
+  return (
+    <motion.div
+      {...motionProps}
+      className={clsx('rounded-lg bg-background-elevated p-6', className)}
+      {...props as any}
+    />
+  )
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,3 +1,4 @@
 export { default as Button } from './Button'
+export { default as Card } from './Card'
 export { default as ThemeToggle } from './ThemeToggle'
 export { ThemeProvider, useTheme } from './ThemeProvider'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,8 +8,13 @@ module.exports = {
     extend: {
       colors: {
         background: 'var(--bg)',
+        'background-elevated': 'var(--bg-elevated)',
         foreground: 'var(--fg)',
+        'foreground-secondary': 'var(--fg-secondary)',
         accent: 'var(--accent)',
+      },
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- tune colors with new futuristic variables
- extend Tailwind theme for Inter font and extra colors
- add Card and Testimonial components with motion
- showcase testimonials on landing page

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b7abdfd6c8323b9af79bfc65c3cbf