### PR TITLE
Add AI estimator prototype

### DIFF
--- a/app/api/ai/analyze-roof/route.ts
+++ b/app/api/ai/analyze-roof/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData()
+  const file = formData.get('file') as File | null
+
+  if (!file) {
+    return NextResponse.json({ error: 'file required' }, { status: 400 })
+  }
+
+  // Placeholder analysis logic
+  const mockResult = {
+    squareFeet: 1500,
+    damage: 'none',
+    confidence: 0.9,
+  }
+
+  return NextResponse.json(mockResult)
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import Dashboard3D from "../../components/Dashboard3D"
 
 // Add dynamic export to prevent static generation
 export const dynamic = 'force-dynamic'
@@ -62,6 +63,7 @@ export default async function Dashboard() {
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900">Dashboard</h1>
           <p className="text-gray-600 mt-2">Welcome back! Here's your business overview.</p>
+        <Dashboard3D />
         </div>
         
         {/* Metrics Grid */}

--- a/app/estimator/page.tsx
+++ b/app/estimator/page.tsx
@@ -1,0 +1,13 @@
+import dynamic from 'next/dynamic'
+
+const Estimator = dynamic(() => import('../components/AIEstimator'), { ssr: false })
+
+export const dynamic = 'force-dynamic'
+
+export default function EstimatorPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-8">
+      <Estimator />
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,3 +5,4 @@
 body {
   @apply bg-bg text-text-primary font-inter;
 }
+@import "./styles/futuristic.css";

--- a/app/lib/ai-models.ts
+++ b/app/lib/ai-models.ts
@@ -1,0 +1,13 @@
+export async function analyzeRoofImage(file: File) {
+  // Placeholder that would call custom vision model
+  const formData = new FormData()
+  formData.append('file', file)
+  const res = await fetch('/api/ai/analyze-roof', { method: 'POST', body: formData })
+  if (!res.ok) throw new Error('analysis failed')
+  return res.json()
+}
+
+export async function chatWithAssistant(message: string) {
+  // Placeholder for GPT-4 integration
+  return `AI says: ${message}`
+}

--- a/app/styles/futuristic.css
+++ b/app/styles/futuristic.css
@@ -1,0 +1,14 @@
+.dropzone {
+  border: 2px dashed rgba(255,255,255,0.3);
+  padding: 2rem;
+  border-radius: 1rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.dropzone.active {
+  background: rgba(255,255,255,0.1);
+}
+.estimator-glass {
+  background: var(--glass);
+  backdrop-filter: var(--blur);
+}

--- a/components/AIEstimator.tsx
+++ b/components/AIEstimator.tsx
@@ -1,0 +1,61 @@
+'use client'
+import { useState } from 'react'
+import { useDropzone } from 'react-dropzone'
+import Button from './ui/Button'
+import '@/app/styles/futuristic.css'
+
+interface AnalysisResult {
+  squareFeet: number
+  damage: string
+  confidence: number
+}
+
+export default function AIEstimator() {
+  const [file, setFile] = useState<File | null>(null)
+  const [result, setResult] = useState<AnalysisResult | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const onDrop = (accepted: File[]) => {
+    if (accepted[0]) {
+      setFile(accepted[0])
+      setResult(null)
+    }
+  }
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop, accept: { 'image/*': [] } })
+
+  const analyze = async () => {
+    if (!file) return
+    const data = new FormData()
+    data.append('file', file)
+    setLoading(true)
+    try {
+      const res = await fetch('/api/ai/analyze-roof', { method: 'POST', body: data })
+      if (res.ok) {
+        const json = await res.json()
+        setResult(json)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="estimator-glass p-6 rounded-xl text-center">
+      <div {...getRootProps()} className={`dropzone ${isDragActive ? 'active' : ''}`}>
+        <input {...getInputProps()} />
+        {file ? <p>{file.name}</p> : <p>Drag & drop a roof photo, or click to select</p>}
+      </div>
+      <Button className="mt-4" onClick={analyze} disabled={!file || loading}>
+        {loading ? 'Analyzing...' : 'Analyze Roof'}
+      </Button>
+      {result && (
+        <div className="mt-4 text-left">
+          <p>Square Feet: {result.squareFeet}</p>
+          <p>Damage: {result.damage}</p>
+          <p>Confidence: {(result.confidence * 100).toFixed(1)}%</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/Dashboard3D.tsx
+++ b/components/Dashboard3D.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { Canvas } from '@react-three/fiber'
+import { Suspense } from 'react'
+
+export default function Dashboard3D() {
+  return (
+    <div className="h-64 w-full bg-gray-900 text-white rounded-xl">
+      <Canvas>
+        <Suspense fallback={null}>
+          {/* Placeholder 3D scene */}
+          <mesh rotation={[0.4, 0.2, 0]}>
+            <boxGeometry args={[2, 2, 2]} />
+            <meshStandardMaterial color="#5E5CE6" />
+          </mesh>
+          <ambientLight intensity={0.5} />
+        </Suspense>
+      </Canvas>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "next": "14.2.30",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-dropzone": "^14.2.3",
         "stripe": "^14.10.0"
       },
       "devDependencies": {
@@ -1311,6 +1312,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -2549,6 +2559,18 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/fill-range": {
@@ -3944,7 +3966,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4418,7 +4439,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -4491,11 +4511,27 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-dropzone": {
+      "version": "14.3.8",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
+      "integrity": "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "next": "14.2.30",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "stripe": "^14.10.0"
+    "stripe": "^14.10.0",
+    "react-dropzone": "^14.2.3"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",


### PR DESCRIPTION
## Summary
- prototype `AIEstimator` component with drag and drop upload
- basic Next.js route for `/api/ai/analyze-roof`
- wire into new `/estimator` page
- add simple 3D dashboard placeholder
- inject futuristic CSS

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated
- [ ] I have reviewed security implications

---

### AI‑Generation
- [x] This PR **was** generated (fully or partially) by **OpenAI Codex**

------
https://chatgpt.com/codex/tasks/task_e_685b8652508c8323b4497041de89f201