### PR TITLE
Fix theme provider server crash

### DIFF
--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -1,28 +1,28 @@
-'use client'
+"use client"
 import { createClient } from '@supabase/supabase-js'
 import Link from 'next/link'
 import { motion } from 'framer-motion'
+import { useEffect, useState } from 'react'
 
 // Add dynamic export to prevent static generation
 export const dynamic = 'force-dynamic'
 
-async function getProducts() {
-  // Handle missing env vars gracefully
+async function fetchProducts() {
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
     console.warn('Supabase environment variables not configured')
     return []
   }
 
   const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   )
-  
+
   const { data } = await supabase
     .from('products')
     .select('*')
     .order('created_at', { ascending: false })
-    
+
   return data || []
 }
 
@@ -35,8 +35,12 @@ const categories = [
   { id: 'safety', name: 'Safety Resources', icon: '⚠️' },
 ]
 
-export default async function Marketplace() {
-  const products = await getProducts()
+export default function Marketplace() {
+  const [products, setProducts] = useState<any[]>([])
+
+  useEffect(() => {
+    fetchProducts().then(setProducts)
+  }, [])
 
   return (
     <div className="min-h-screen bg-bg text-text-primary">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client"
 import { motion } from 'framer-motion'
 import FeatureCard from '../components/FeatureCard'
 import Testimonial from '../components/Testimonial'

--- a/components/ui/ThemeProvider.tsx
+++ b/components/ui/ThemeProvider.tsx
@@ -8,7 +8,13 @@ const ThemeContext = createContext<ThemeCtx>({ theme: 'dark', toggle: () => {} }
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>('dark')
+
+  if (typeof window === 'undefined') {
+    return <>{children}</>
+  }
+
   useEffect(() => {
+    if (typeof document === 'undefined') return
     if (theme === 'dark') {
       document.documentElement.classList.remove('light')
     } else {


### PR DESCRIPTION
## Summary
- prevent ThemeProvider crash on the server by skipping DOM access
- fetch marketplace data on the client using useEffect

## Testing
- `npm run build` *(fails: `useContext` still crashing)*

------
https://chatgpt.com/codex/tasks/task_e_685bfa54ece48323a0a10ea31f915402