### PR TITLE
Enhance Copilot streaming & persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ Public SaaS React + FastAPI system for MyRoofGenius.
 
 - Added universal `/api/copilot` endpoint and basic Copilot UI integration.
 - Introduced feature flags `AI_COPILOT_ENABLED`, `AR_MODE_ENABLED`, and `MAINTENANCE_MODE`.
+- `/api/copilot` now streams responses, stores chat history in Supabase and
+  supports voice input and quick actions.

--- a/app/api/copilot/route.ts
+++ b/app/api/copilot/route.ts
@@ -1,5 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getPrompt } from '../../../prompts'
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * Helper to create a Supabase client using the service role key so the
+ * endpoint can store and read chat history. If the env vars are missing the
+ * function returns null and the API operates in a stateless mode.
+ */
+function createAdminClient(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) return null
+  return createClient(url, key)
+}
+
+/**
+ * Fetch a prompt template from the backend FastAPI service when available.
+ * Falls back to the static prompt list used in tests.
+ */
 
 async function fetchPrompt(name: string) {
   const baseUrl = process.env.API_BASE_URL
@@ -16,9 +34,105 @@ async function fetchPrompt(name: string) {
   return getPrompt(name)
 }
 
-export async function POST(req: NextRequest) {
-  const { message } = await req.json()
+/**
+ * Generate a response based on the user message. This demo implementation
+ * simply echoes the input and checks for a few hard‑coded commands that
+ * retrieve data from Supabase. In a real implementation this would call an
+ * LLM with the full chat history.
+ */
+async function generateAnswer(
+  message: string,
+  supabase: SupabaseClient | null
+): Promise<string> {
   const base = await fetchPrompt('copilot_intro')
-  const reply = `${base} You said: ${message}`
-  return NextResponse.json({ reply })
+
+  if (supabase) {
+    if (/last\s+5\s+orders/i.test(message)) {
+      const { data } = await supabase
+        .from('orders')
+        .select('id, amount, created_at')
+        .order('created_at', { ascending: false })
+        .limit(5)
+      if (data?.length) {
+        const list = data
+          .map((o) => `${o.id} - $${o.amount} on ${new Date(o.created_at).toLocaleDateString()}`)
+          .join('\n')
+        return `${base}\nHere are your last 5 orders:\n${list}`
+      }
+    }
+
+    if (/best.*selling.*template/i.test(message)) {
+      const { data } = await supabase
+        .from('products')
+        .select('name')
+        .order('sales', { ascending: false })
+        .limit(1)
+        .single()
+      if (data) {
+        return `${base}\nYour best-selling template is ${data.name}.`
+      }
+    }
+  }
+
+  return `${base} You said: ${message}`
+}
+
+export async function POST(req: NextRequest) {
+  const { message, sessionId } = await req.json()
+
+  const supabase = createAdminClient()
+  const userId = 'demo-user'
+  const sid = sessionId || crypto.randomUUID()
+
+  if (supabase) {
+    await supabase.from('copilot_messages').insert({
+      session_id: sid,
+      user_id: userId,
+      role: 'user',
+      content: message,
+    })
+  }
+
+  const answer = await generateAnswer(message, supabase)
+
+  if (supabase) {
+    await supabase.from('copilot_messages').insert({
+      session_id: sid,
+      user_id: userId,
+      role: 'assistant',
+      content: answer,
+    })
+  }
+
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream({
+    async start(controller) {
+      for (const token of answer.split(' ')) {
+        controller.enqueue(encoder.encode(token + ' '))
+        await new Promise((r) => setTimeout(r, 50))
+      }
+      controller.close()
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Session-Id': sid,
+    },
+  })
+}
+
+export async function GET(req: NextRequest) {
+  const supabase = createAdminClient()
+  const { searchParams } = new URL(req.url)
+  const sid = searchParams.get('sessionId')
+  if (!supabase || !sid) return NextResponse.json({ history: [] })
+  const { data } = await supabase
+    .from('copilot_messages')
+    .select('role, content, created_at')
+    .eq('session_id', sid)
+    .order('created_at', { ascending: true })
+    .limit(50)
+  return NextResponse.json({ history: data || [] })
 }

--- a/components/CopilotPanel.tsx
+++ b/components/CopilotPanel.tsx
@@ -1,31 +1,110 @@
 'use client'
 import { motion } from 'framer-motion'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+
+type Msg = {
+  role: 'user' | 'assistant'
+  content: string
+}
 
 export default function CopilotPanel({ open, onClose }: { open: boolean; onClose: () => void }) {
   const [input, setInput] = useState('')
-  const [reply, setReply] = useState('')
   const [loading, setLoading] = useState(false)
+  const [sessionId, setSessionId] = useState<string | null>(null)
+  const [messages, setMessages] = useState<Msg[]>([])
+  const [recording, setRecording] = useState(false)
+  const recognizer = useRef<SpeechRecognition | null>(null)
+
+  const userRole = 'field' // TODO: replace with real auth role
+
+  useEffect(() => {
+    if (open) {
+      const stored = localStorage.getItem('copilotSession')
+      const sid = stored || crypto.randomUUID()
+      setSessionId(sid)
+      localStorage.setItem('copilotSession', sid)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (sessionId) {
+      fetch(`/api/copilot?sessionId=${sessionId}`)
+        .then((res) => res.json())
+        .then((d) => setMessages(d.history || []))
+        .catch(() => {})
+    }
+  }, [sessionId])
 
   if (!open) return null
 
-  const send = async () => {
-    if (!input) return
+  const appendAssistant = (text: string) => {
+    setMessages((m) => {
+      const copy = [...m]
+      const last = copy[copy.length - 1]
+      if (last && last.role === 'assistant') {
+        copy[copy.length - 1] = { role: 'assistant', content: text }
+        return copy
+      }
+      return [...copy, { role: 'assistant', content: text }]
+    })
+  }
+
+  const send = async (content?: string) => {
+    const msg = content ?? input
+    if (!msg) return
+    setInput('')
     setLoading(true)
+    setMessages((m) => [...m, { role: 'user', content: msg }])
     try {
       const res = await fetch('/api/copilot', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: input }),
+        body: JSON.stringify({ message: msg, sessionId }),
       })
-      if (res.ok) {
-        const data = await res.json()
-        setReply(data.reply)
+
+      const sid = res.headers.get('x-session-id')
+      if (sid) {
+        setSessionId(sid)
+        localStorage.setItem('copilotSession', sid)
+      }
+
+      const reader = res.body?.getReader()
+      const decoder = new TextDecoder()
+      let acc = ''
+      if (reader) {
+        while (true) {
+          const { value, done } = await reader.read()
+          if (done) break
+          acc += decoder.decode(value)
+          appendAssistant(acc)
+        }
       }
     } finally {
       setLoading(false)
     }
   }
+
+  const startVoice = () => {
+    const Rec = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+    if (!Rec) return
+    recognizer.current = new Rec()
+    recognizer.current.lang = 'en-US'
+    recognizer.current.interimResults = false
+    recognizer.current.onresult = (e: any) => {
+      const t = e.results[0][0].transcript
+      setInput(t)
+    }
+    recognizer.current.onend = () => setRecording(false)
+    recognizer.current.start()
+    setRecording(true)
+  }
+
+  const quickActions: Record<string, string[]> = {
+    field: ['Generate an estimate'],
+    pm: ['Create a support ticket'],
+    executive: ['Show best-selling template'],
+  }
+
 
   return (
     <motion.aside
@@ -36,20 +115,45 @@ export default function CopilotPanel({ open, onClose }: { open: boolean; onClose
     >
       <button className="absolute top-4 right-4 text-accent font-bold" onClick={onClose}>✕</button>
       <h3 className="text-2xl font-bold mb-4">AI Copilot</h3>
-      <textarea
-        className="w-full rounded-lg px-3 py-2 mb-2 bg-bg-card text-text-primary"
-        placeholder="Ask AI about your project..."
-        value={input}
-        onChange={(e) => setInput(e.target.value)}
-      />
-      <button
-        onClick={send}
-        className="bg-accent text-white px-4 py-2 rounded-md disabled:opacity-50"
-        disabled={loading}
-      >
-        {loading ? 'Thinking...' : 'Send'}
-      </button>
-      {reply && <p className="mt-4 text-text-secondary">{reply}</p>}
+      <div className="flex gap-2 mb-4">
+        {quickActions[userRole].map((a) => (
+          <button
+            key={a}
+            onClick={() => send(a)}
+            className="px-3 py-1 rounded-lg bg-[rgba(255,255,255,0.1)] hover:bg-[rgba(255,255,255,0.2)]"
+          >
+            {a}
+          </button>
+        ))}
+      </div>
+      <div className="overflow-y-auto h-[60%] mb-4 pr-2">
+        {messages.map((m, i) => (
+          <p key={i} className={m.role === 'user' ? 'text-right text-blue-200' : 'text-green-200'}>
+            {m.content}
+          </p>
+        ))}
+      </div>
+      <div className="flex gap-2 items-center">
+        <textarea
+          className="flex-1 rounded-lg px-3 py-2 bg-bg-card text-text-primary"
+          placeholder="Ask AI about your project..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button
+          onClick={startVoice}
+          className="px-3 py-2 rounded-lg bg-[rgba(255,255,255,0.1)]"
+        >
+          {recording ? '🎙️...' : '🎙️'}
+        </button>
+        <button
+          onClick={() => send()}
+          className="bg-accent text-white px-4 py-2 rounded-md disabled:opacity-50"
+          disabled={loading}
+        >
+          {loading ? '...' : 'Send'}
+        </button>
+      </div>
     </motion.aside>
   )
 }


### PR DESCRIPTION
## Summary
- extend `/api/copilot` with streaming responses
- store and load chat history from Supabase
- include mock data lookups for orders/products
- redesign Copilot panel UI with history, voice input and actions
- document new copilot capabilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c2163cb6083238c4ef1b1f6feaec1