### PR TITLE
Add Continue Shopping link

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -42,6 +42,15 @@ export default async function Account() {
           <h2 className="text-xl font-semibold mb-4">Account Settings</h2>
           <p className="text-gray-600">Authentication coming soon...</p>
         </div>
+
+        <div className="mt-8 text-center">
+          <a
+            href="/marketplace"
+            className="text-blue-600 hover:underline font-semibold"
+          >
+            Continue Shopping
+          </a>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- add link on account page to continue shopping at marketplace

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2d5aaa5083239912e3226a7548de