### PR TITLE
Set up more CI workflows

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,0 +1,14 @@
+name: Production Health Check
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check Health API
+      run: |
+        curl -f https://www.myroofgenius.com/api/health || exit 1

--- a/.github/workflows/meta-lint.yml
+++ b/.github/workflows/meta-lint.yml
@@ -1,0 +1,13 @@
+name: SEO & Meta Validation
+
+on: [push]
+
+jobs:
+  meta:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Validate GA, Meta, OG
+      run: |
+        grep NEXT_PUBLIC_GA_MEASUREMENT_ID .env.example || exit 1
+        grep 'og:image' app/layout.tsx || echo "⚠️ Missing OG tags"

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -1,0 +1,15 @@
+name: Seed Supabase
+
+on:
+  workflow_dispatch:
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: npm ci
+    - run: npm run seed
+      env:
+        NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+        SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,15 @@
+name: Deploy Preview (Staging)
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: npm install -g vercel
+    - run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+    - run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+    - run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,6 @@ jobs:
     - run: npm ci
     - run: npm run lint
     - run: npm run test
-    - run: npm run test:e2e
+    - run: npx playwright install
+    - run: npm install -g start-server-and-test
+    - run: start-server-and-test dev http://localhost:3000 test:e2e

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+export const dynamic = 'force-dynamic'
 import { useState, useEffect } from 'react'
 import { createClient } from '@supabase/supabase-js'
 import { Users, Package, DollarSign, FileText, Settings as SettingsIcon, BarChart3 } from 'lucide-react'

--- a/app/cancel/page.tsx
+++ b/app/cancel/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 export default function Cancel() {
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center">

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,4 +1,5 @@
 'use client'
+export const dynamic = 'force-dynamic'
 import { useEffect } from 'react'
 import { sendAlert } from './lib/notify'
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,8 @@ import CopilotWrapper from '../components/layout/CopilotWrapper'
 import './lib/sentry'
 import { maintenanceMode, aiCopilotEnabled, arModeEnabled } from './lib/features'
 
+export const dynamic = 'force-dynamic'
+
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata = {

--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -1,4 +1,5 @@
 "use client"
+export const dynamic = 'force-dynamic'
 import { createClient } from '@supabase/supabase-js'
 import Link from 'next/link'
 import { motion } from 'framer-motion'

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,4 +1,5 @@
 'use client'
+export const dynamic = 'force-dynamic'
 
 export default function NotFound() {
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 "use client"
+export const dynamic = 'force-dynamic'
 import { motion } from 'framer-motion'
 import FeatureCard from '../components/FeatureCard'
 import Testimonial from '../components/Testimonial'

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+export const dynamic = 'force-dynamic'
 
 import { useState, useEffect } from 'react'
 


### PR DESCRIPTION
## Summary
- run e2e tests via start-server-and-test
- add staging preview on PRs to main
- seed Supabase on demand
- monitor production health
- lint for GA & OG tags
- mark app pages as dynamic

## Testing
- `npm run test`
- `npm run lint`
- `npx start-server-and-test dev http://localhost:3000 "npx playwright test"` *(fails: page.goto net::ERR_CONNECTION_REFUSED)*
- `npm run build` *(fails: Export encountered errors on following paths)*

------
https://chatgpt.com/codex/tasks/task_e_685c6abeecf48323b6cd102a680c8301