### PR TITLE
Finalize utility scripts and copilot streaming

### DIFF
--- a/app/api/analytics/track/route.ts
+++ b/app/api/analytics/track/route.ts
@@ -39,8 +39,6 @@ export async function POST(request: NextRequest) {
     // Also send to Google Analytics if configured
     if (process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && typeof window !== 'undefined' && (window as any).gtag) {
       (window as any).gtag('event', event_type, event_data)
-    } else {
-      console.log('[analytics]', event_type, event_data)
     }
     
     return NextResponse.json({ success: true })

--- a/scripts/env-verify.ts
+++ b/scripts/env-verify.ts
@@ -1,0 +1,24 @@
+import fs from 'fs'
+
+const examplePath = '.env.example'
+const contents = fs.readFileSync(examplePath, 'utf-8')
+
+const required = contents
+  .split(/\r?\n/)
+  .map(line => line.trim())
+  .filter(line => line && !line.startsWith('#'))
+  .map(line => line.split('=')[0])
+
+let missing: string[] = []
+for (const key of required) {
+  if (!process.env[key]) {
+    missing.push(key)
+  }
+}
+
+if (missing.length) {
+  console.error('Missing environment variables:', missing.join(', '))
+  process.exit(1)
+}
+
+console.log('All environment variables loaded')

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm run build
+
+git push origin main
+
+if [ -n "${VERCEL_TOKEN:-}" ]; then
+  npx vercel deploy --prebuilt --prod --token "$VERCEL_TOKEN"
+else
+  echo "VERCEL_TOKEN not set; skipping vercel deploy" >&2
+fi


### PR DESCRIPTION
## Summary
- add env variable verification script and deploy helper script
- improve copilot API with streaming OpenAI responses
- expose streaming helper in LLM library
- clean analytics API logs

## Testing
- `npm run lint`
- `npm run test`
- `npm run test:e2e` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_685c765078d88323b2acc746078607a1