### PR TITLE
Add Field Apps page with navigation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ npm run test:e2e
 ## 28 Jun 2025 Updates
 
 - Added AI Tools page with links to Claude-powered dashboards and forms.
+
+## 1 Jul 2025 Updates
+
+- Added Field Apps page exposing smart inspection, proposal, and punchlist utilities.

--- a/app/fieldapps/page.tsx
+++ b/app/fieldapps/page.tsx
@@ -1,0 +1,44 @@
+"use client"
+import Card from '../../components/ui/Card'
+import Button from '../../components/ui/Button'
+
+export const dynamic = 'force-dynamic'
+
+export default function FieldApps() {
+  const apps = [
+    {
+      title: 'Smart Field Inspection',
+      description: 'Capture photos, annotate issues, and auto-log GPS/metadata.',
+      url: 'https://claude.ai/inspection'
+    },
+    {
+      title: 'On-Site Proposal Generator',
+      description: 'Instantly draft proposals and estimates from your phone.',
+      url: 'https://claude.ai/proposal'
+    },
+    {
+      title: 'Real-Time Punchlist Dashboard',
+      description: 'Track project tasks collaboratively with AI suggestions.',
+      url: 'https://claude.ai/punchlist'
+    }
+  ]
+  return (
+    <main className="min-h-screen pt-32 bg-bg text-text-primary px-4">
+      <h1 className="text-4xl font-bold text-center mb-8">Field Apps</h1>
+      <p className="text-center text-text-secondary mb-12">
+        Quick links to Claude-powered utilities for crews and partners.
+      </p>
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto">
+        {apps.map((app) => (
+          <Card key={app.title} className="flex flex-col justify-between">
+            <div>
+              <h3 className="text-xl font-semibold mb-2">{app.title}</h3>
+              <p className="text-text-secondary mb-4">{app.description}</p>
+            </div>
+            <Button onClick={() => window.open(app.url, '_blank')}>Open App</Button>
+          </Card>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -8,6 +8,7 @@ export default function Navbar() {
   const [open, setOpen] = useState(false)
   const links = [
     { href: '/', label: 'Home' },
+    { href: '/fieldapps', label: 'Field Apps' },
     { href: '/tools', label: 'Tools' },
     { href: '/marketplace', label: 'Marketplace' },
     { href: '/blog', label: 'Blog' },

--- a/tests/e2e/fieldapps.spec.ts
+++ b/tests/e2e/fieldapps.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Field Apps page", () => {
+  test("loads correctly", async ({ page }) => {
+    await page.goto("/fieldapps");
+    await expect(page.locator("text=Field Apps")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add new **Field Apps** page with links to field inspection, proposal and punchlist utilities
- surface the new page in the navbar
- add a Playwright test for the page
- document the feature in README

## Testing
- `npm run type-check`
- `npm test`
- `npm run test:e2e` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685d5742f45c832399c302faff7b936e