### PR TITLE
Add marketplace recommendation scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/
 *.png
 *.xlsx
 *.docx
+\ntsconfig.tsbuildinfo

--- a/app/api/marketplace/recommendations/route.ts
+++ b/app/api/marketplace/recommendations/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { MarketplaceRecommender } from '../../../../lib/ai/marketplace-recommender'
+import { RecommendationContext } from '../../../../types/marketplace'
+
+export async function POST(request: NextRequest) {
+  try {
+    const context: RecommendationContext = await request.json()
+    const recommender = new MarketplaceRecommender()
+    const [products, contractors] = await Promise.all([
+      recommender.getProductRecommendations(context),
+      recommender.getContractorRecommendations(context)
+    ])
+    return NextResponse.json({ products, contractors, generatedAt: new Date().toISOString() })
+  } catch (error) {
+    console.error('Recommendation error:', error)
+    return NextResponse.json({ error: 'Failed to generate recommendations' }, { status: 500 })
+  }
+}

--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -5,6 +5,9 @@ import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { useEffect, useState } from 'react'
 import { Search, Filter, ChevronDown, Star, ShoppingCart, Eye } from 'lucide-react'
+import ProductCarousel from '../../components/marketplace/ProductCarousel'
+import ContractorGrid from '../../components/marketplace/ContractorGrid'
+import { Product as RecommendedProduct, Contractor, RecommendationContext } from '../../types/marketplace'
 
 const categories = [
   { id: 'all', name: 'All Products', icon: '🏠' },
@@ -45,6 +48,10 @@ interface Product {
 export default function Marketplace() {
   const [products, setProducts] = useState<Product[]>([])
   const [filteredProducts, setFilteredProducts] = useState<Product[]>([])
+  const [recommendations, setRecommendations] = useState<{
+    products: RecommendedProduct[]
+    contractors: Contractor[]
+  } | null>(null)
   const [selectedCategory, setSelectedCategory] = useState('all')
   const [searchTerm, setSearchTerm] = useState('')
   const [sortBy, setSortBy] = useState('popular')
@@ -54,6 +61,7 @@ export default function Marketplace() {
 
   useEffect(() => {
     fetchProducts()
+    fetchRecommendations()
   }, [])
 
   useEffect(() => {
@@ -85,6 +93,22 @@ export default function Marketplace() {
       setProducts(enrichedProducts)
     }
     setLoading(false)
+  }
+
+  async function fetchRecommendations() {
+    try {
+      const res = await fetch('/api/marketplace/recommendations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}) as any
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setRecommendations(data)
+      }
+    } catch (error) {
+      console.error('Failed to fetch recommendations', error)
+    }
   }
 
   function filterAndSortProducts() {
@@ -272,6 +296,12 @@ export default function Marketplace() {
                 Showing {filteredProducts.length} of {products.length} products
               </p>
             </div>
+
+            {recommendations?.products && recommendations.products.length > 0 && (
+              <div className="mb-8">
+                <ProductCarousel products={recommendations.products} />
+              </div>
+            )}
 
             {/* Featured Products */}
             {filteredProducts.filter(p => p.is_featured).length > 0 && (
@@ -483,6 +513,13 @@ export default function Marketplace() {
                 <button className="px-6 py-3 border border-gray-300 rounded-lg hover:bg-gray-50">
                   Load More Products
                 </button>
+              </div>
+            )}
+
+            {recommendations?.contractors && recommendations.contractors.length > 0 && (
+              <div className="mt-12">
+                <h2 className="text-2xl font-bold mb-4">Recommended Contractors</h2>
+                <ContractorGrid contractors={recommendations.contractors} />
               </div>
             )}
           </main>

--- a/components/marketplace/AIRecommendationEngine.tsx
+++ b/components/marketplace/AIRecommendationEngine.tsx
@@ -1,0 +1,19 @@
+'use client'
+import { useEffect } from 'react'
+import { RecommendationContext } from '../../types/marketplace'
+
+export default function AIRecommendationEngine({ context, onUpdate }: { context: RecommendationContext; onUpdate: (data: any) => void }) {
+  useEffect(() => {
+    const fetchData = async () => {
+      const res = await fetch('/api/marketplace/recommendations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(context)
+      })
+      const data = await res.json()
+      onUpdate(data)
+    }
+    fetchData()
+  }, [context, onUpdate])
+  return null
+}

--- a/components/marketplace/ContractorCard.tsx
+++ b/components/marketplace/ContractorCard.tsx
@@ -1,0 +1,12 @@
+'use client'
+import { Contractor } from '../../types/marketplace'
+import Card from '../ui/Card'
+
+export default function ContractorCard({ contractor }: { contractor: Contractor }) {
+  return (
+    <Card className="flex flex-col gap-2">
+      <h3 className="font-semibold">{contractor.businessName}</h3>
+      <p className="text-sm text-text-secondary">Rating: {contractor.rating}/5</p>
+    </Card>
+  )
+}

--- a/components/marketplace/ContractorGrid.tsx
+++ b/components/marketplace/ContractorGrid.tsx
@@ -1,0 +1,13 @@
+'use client'
+import { Contractor } from '../../types/marketplace'
+import ContractorCard from './ContractorCard'
+
+export default function ContractorGrid({ contractors }: { contractors: Contractor[] }) {
+  return (
+    <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {contractors.map((c) => (
+        <ContractorCard key={c.id} contractor={c} />
+      ))}
+    </div>
+  )
+}

--- a/components/marketplace/ProductCarousel.tsx
+++ b/components/marketplace/ProductCarousel.tsx
@@ -1,0 +1,58 @@
+'use client'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useState, useEffect } from 'react'
+import { Product } from '../../types/marketplace'
+import GlassPanel from '../ui/Card'
+
+interface ProductCarouselProps {
+  products: Product[]
+  isLoading?: boolean
+  title?: string
+}
+
+export default function ProductCarousel({
+  products,
+  isLoading,
+  title = 'AI-Recommended Products'
+}: ProductCarouselProps) {
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [autoPlay, setAutoPlay] = useState(true)
+
+  useEffect(() => {
+    if (!autoPlay || products.length === 0) return
+    const interval = setInterval(() => {
+      setCurrentIndex((prev) => (prev + 1) % products.length)
+    }, 4000)
+    return () => clearInterval(interval)
+  }, [autoPlay, products.length])
+
+  return (
+    <div className="relative w-full" onMouseEnter={() => setAutoPlay(false)} onMouseLeave={() => setAutoPlay(true)}>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-bold">{title}</h2>
+        <div className="flex gap-2">
+          {products.map((_, idx) => (
+            <button
+              key={idx}
+              onClick={() => setCurrentIndex(idx)}
+              className={`w-2 h-2 rounded-full ${idx === currentIndex ? 'bg-blue-500 w-4' : 'bg-gray-400'}`}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="relative h-72 overflow-hidden rounded-2xl">
+        <AnimatePresence mode="wait">
+          {isLoading ? (
+            <motion.div key="loading" className="absolute inset-0 flex items-center justify-center" />
+          ) : (
+            <motion.div key={currentIndex} initial={{ opacity: 0, x: 100 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -100 }} className="absolute inset-0">
+              <GlassPanel className="h-full p-6">
+                {products[currentIndex]?.name}
+              </GlassPanel>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  )
+}

--- a/lib/ai/marketplace-recommender.ts
+++ b/lib/ai/marketplace-recommender.ts
@@ -1,0 +1,37 @@
+import { Product, Contractor, RecommendationContext } from '../../types/marketplace'
+
+export class MarketplaceRecommender {
+  async getProductRecommendations(
+    context: RecommendationContext,
+    limit = 12
+  ): Promise<Product[]> {
+    // TODO: implement vector search and AI reasoning
+    return []
+  }
+
+  async getContractorRecommendations(
+    context: RecommendationContext,
+    limit = 6
+  ): Promise<Contractor[]> {
+    // TODO: call LLM for contractor ranking
+    const response: any = {}
+    return this.processContractorRecommendations(response)
+  }
+
+  private async generateContextEmbedding(context: RecommendationContext) {
+    // TODO: embeddings
+  }
+
+  private async queryProductVectors(embedding: number[], limit: number) {
+    // TODO: vector similarity search
+  }
+
+  private async enhanceWithAIReasoning(products: Product[], context: RecommendationContext) {
+    // TODO: add AI-generated reasons
+  }
+
+  private processContractorRecommendations(_response: any): Contractor[] {
+    // TODO: parse response
+    return []
+  }
+}

--- a/lib/analytics/user-behavior.ts
+++ b/lib/analytics/user-behavior.ts
@@ -1,0 +1,8 @@
+export function trackMarketplaceView(productId: string) {
+  // TODO: send event to analytics system
+  console.log('track view', productId)
+}
+
+export function trackContractorView(contractorId: string) {
+  console.log('track contractor view', contractorId)
+}

--- a/types/marketplace.ts
+++ b/types/marketplace.ts
@@ -1,0 +1,41 @@
+export interface Product {
+  id: string
+  name: string
+  category: 'materials' | 'tools' | 'services'
+  price: number
+  rating: number
+  compatibilityScore?: number
+  aiRecommendationReason?: string
+  vendor: {
+    id: string
+    name: string
+    verified: boolean
+  }
+}
+
+export interface Contractor {
+  id: string
+  businessName: string
+  specialties: string[]
+  rating: number
+  completedProjects: number
+  responseTime: string
+  priceRange: '$' | '$$' | '$$$'
+  aiMatchScore?: number
+  aiMatchReasons?: string[]
+}
+
+export interface RecommendationContext {
+  projectType?: string
+  roofType?: string
+  budget?: number
+  timeline?: string
+  location?: {
+    lat: number
+    lng: number
+  }
+  userHistory?: {
+    viewedProducts: string[]
+    savedContractors: string[]
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold marketplace recommendation engine
- add API route and types for product and contractor suggestions
- integrate ProductCarousel and ContractorGrid on Marketplace page
- ignore TypeScript build info

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e08253e288323915429eb710abc6d