### PR TITLE
Add simplified admin APIs and copilot stream

### DIFF
--- a/app/api/admin/orders/route.ts
+++ b/app/api/admin/orders/route.ts
@@ -1,21 +1,43 @@
-import { NextResponse } from 'next/server'
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
-import { cookies } from 'next/headers'
 
-export async function GET() {
-  const supabase = createRouteHandlerClient({ cookies })
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { data: profile } = await supabase.from('user_profiles').select('is_admin').eq('user_id', user.id).single()
-  if (!profile?.is_admin) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+const admin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
 
-  const admin = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const userId = searchParams.get('user_id')
+  if (!userId) {
+    return NextResponse.json({ error: 'user_id required' }, { status: 400 })
+  }
+
+  const { data: profile } = await admin
+    .from('user_profiles')
+    .select('is_admin')
+    .eq('user_id', userId)
+    .single()
+
+  if (!profile?.is_admin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
   const { data } = await admin
     .from('orders')
-    .select('id, customer_email, amount, status, created_at, products (name)')
+    .select(
+      'id, amount, created_at, products(name), user_profiles(email)'
+    )
     .order('created_at', { ascending: false })
-    .limit(50)
+    .limit(20)
 
-  return NextResponse.json({ orders: data || [] })
+  const orders = (data || []).map((o: any) => ({
+    order_id: o.id,
+    email: o.user_profiles?.email || '',
+    product: o.products?.name || '',
+    amount: Number(o.amount),
+    created_at: o.created_at
+  }))
+
+  return NextResponse.json(orders)
 }

--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -1,37 +1,42 @@
-import { NextResponse } from 'next/server'
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
-import { cookies } from 'next/headers'
 
-export async function GET() {
-  const supabase = createRouteHandlerClient({ cookies })
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { data: profile } = await supabase.from('user_profiles').select('is_admin').eq('user_id', user.id).single()
-  if (!profile?.is_admin) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+const admin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
 
-  const admin = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
-  const [usersRes, ordersRes, productsRes, ticketsRes] = await Promise.all([
-    admin.from('user_profiles').select('id', { count: 'exact', head: true }),
-    admin.from('orders').select('id, amount, created_at', { count: 'exact' }),
-    admin.from('products').select('id', { count: 'exact' }).eq('is_active', true),
-    admin.from('support_tickets').select('id', { count: 'exact' }).eq('status', 'open')
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const userId = searchParams.get('user_id')
+  if (!userId) {
+    return NextResponse.json({ error: 'user_id required' }, { status: 400 })
+  }
+
+  const { data: profile } = await admin
+    .from('user_profiles')
+    .select('is_admin')
+    .eq('user_id', userId)
+    .single()
+
+  if (!profile?.is_admin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const [usersRes, ordersRes, productsRes] = await Promise.all([
+    admin.from('auth.users').select('id', { count: 'exact', head: true }),
+    admin.from('orders').select('amount', { count: 'exact' }),
+    admin.from('products').select('id', { count: 'exact' }).eq('is_active', true)
   ])
-  const totalRevenue = ordersRes.data?.reduce((sum: number, o: any) => sum + o.amount, 0) || 0
-  const revenueByMonth: Record<string, number> = {}
-  ;(ordersRes.data || []).forEach((o: any) => {
-    const month = o.created_at.slice(0,7)
-    revenueByMonth[month] = (revenueByMonth[month] || 0) + o.amount
-  })
-  const months = Object.keys(revenueByMonth).sort().slice(-12)
-  const monthlyRevenue = months.map(m => ({ month: m, revenue: revenueByMonth[m] }))
+
+  const totalRevenue =
+    ordersRes.data?.reduce((sum: number, o: any) => sum + Number(o.amount), 0) ||
+    0
 
   return NextResponse.json({
     totalUsers: usersRes.count || 0,
     totalOrders: ordersRes.count || 0,
     totalRevenue,
-    activeProducts: productsRes.count || 0,
-    pendingTickets: ticketsRes.count || 0,
-    monthlyRevenue
+    activeProducts: productsRes.count || 0
   })
 }

--- a/app/api/copilot/route.ts
+++ b/app/api/copilot/route.ts
@@ -1,116 +1,40 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient, SupabaseClient } from '@supabase/supabase-js'
-import { chat, chatStream, ChatMessage } from '../../lib/llm'
+import { chatStream, ChatMessage } from '../../lib/llm'
 
-function createAdminClient(): SupabaseClient | null {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
-  if (!url || !key) return null
-  return createClient(url, key)
-}
-
-async function fetchPromptTemplate(role: string): Promise<string> {
-  let promptName = 'copilot_intro'
-  if (role === 'field') promptName = 'copilot_field'
-  else if (role === 'pm') promptName = 'copilot_pm'
-  const { fetchPrompt } = await import('../../../prompts/service')
-  const prompt = await fetchPrompt(promptName)
-  return prompt || 'You are a helpful roofing assistant.'
-}
+const sessions: Record<string, ChatMessage[]> = {}
 
 export async function POST(req: NextRequest) {
-  const { message, session_id, user_role } = await req.json()
+  const { message, sessionId } = await req.json()
   if (!message) {
     return NextResponse.json({ error: 'Message is required' }, { status: 400 })
   }
 
-  const supabase = createAdminClient()
-  const sessionId = session_id || crypto.randomUUID()
-  let userId: string | null = null
-  const authHeader = req.headers.get('authorization') || req.headers.get('Authorization')
-  if (authHeader) {
-    const token = authHeader.replace('Bearer ', '')
-    try {
-      const [, payloadBase64] = token.split('.')
-      const payload = JSON.parse(Buffer.from(payloadBase64, 'base64').toString('utf-8'))
-      userId = payload.sub || null
-    } catch {
-      userId = null
-    }
-  }
-
-  if (supabase) {
-    await supabase.from('copilot_messages').insert({
-      session_id: sessionId,
-      user_id: userId,
-      role: 'user',
-      content: message
-    })
-  }
-
-  const systemPrompt = await fetchPromptTemplate(user_role)
-  const messages: ChatMessage[] = []
-  if (systemPrompt) messages.push({ role: 'system', content: systemPrompt })
-  if (supabase) {
-    const { data: history } = await supabase
-      .from('copilot_messages')
-      .select('role, content')
-      .eq('session_id', sessionId)
-      .order('created_at', { ascending: true })
-      .limit(20)
-    if (history && history.length > 0) {
-      for (const msg of history) {
-        messages.push({ role: msg.role as 'user' | 'assistant', content: msg.content })
-      }
-    } else {
-      messages.push({ role: 'user', content: message })
-    }
-  } else {
-    messages.push({ role: 'user', content: message })
-  }
+  const sid = sessionId || crypto.randomUUID()
+  sessions[sid] = sessions[sid] || []
+  sessions[sid].push({ role: 'user', content: message })
 
   let responseText = ''
   const encoder = new TextEncoder()
   const stream = new ReadableStream({
     async start(controller) {
-      try {
-        await chatStream(messages, async (chunk) => {
-          responseText += chunk
-          controller.enqueue(encoder.encode(chunk))
-        })
-        controller.close()
-      } catch (error) {
-        console.error('Copilot AI Error:', error)
-        controller.enqueue(encoder.encode("I'm sorry, I couldn't find an answer. Please try again."))
-        controller.close()
-      }
-      if (supabase) {
-        await supabase.from('copilot_messages').insert({
-          session_id: sessionId,
-          user_id: userId,
-          role: 'assistant',
-          content: responseText
-        })
-      }
+      await chatStream(sessions[sid], (chunk) => {
+        responseText += chunk
+        controller.enqueue(encoder.encode(chunk))
+      })
+      controller.close()
+      sessions[sid].push({ role: 'assistant', content: responseText })
     }
   })
+
   return new Response(stream, {
-    headers: { 'Content-Type': 'text/plain; charset=utf-8', 'X-Session-Id': sessionId }
+    headers: { 'Content-Type': 'text/plain; charset=utf-8', 'X-Session-Id': sid }
   })
 }
 
 export async function GET(req: NextRequest) {
-  const supabase = createAdminClient()
   const { searchParams } = new URL(req.url)
   const sid = searchParams.get('sessionId')
-  if (!supabase || !sid) {
-    return NextResponse.json({ history: [] })
-  }
-  const { data } = await supabase
-    .from('copilot_messages')
-    .select('role, content, created_at')
-    .eq('session_id', sid)
-    .order('created_at', { ascending: true })
-    .limit(50)
-  return NextResponse.json({ history: data || [] })
+  const history = (sid && sessions[sid]) || []
+  return NextResponse.json({ history })
 }
+


### PR DESCRIPTION
## Summary
- update admin stats API to accept `user_id` and return condensed stats
- simplify copilot API with in-memory chat history and streaming
- update admin orders API to list recent orders with product and user info

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated
- [ ] I have reviewed security implications

### AI‑Generation
- [x] This PR **was** generated (fully or partially) by **OpenAI Codex**

------
https://chatgpt.com/codex/tasks/task_e_685f4a829e548323baa6e071c76c7a57