### PR TITLE
feat: add announcement banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Sitewide announcement banner with Supabase-backed announcements.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider, RoleProvider, RoleSwitcher, ARModeProvider } from '../co
 import type { ReactNode } from 'react';
 import { AuthProvider } from '../src/context/AuthContext';
 import Navbar from '../components/Navbar';
+import AnnouncementBanner from '../components/AnnouncementBanner';
 import ErrorBoundary from '../components/ErrorBoundary';
 import CopilotWrapper from '../components/layout/CopilotWrapper';
 import './lib/sentry';
@@ -44,6 +45,7 @@ export default function RootLayout({
               {arModeEnabled ? (
                 <ARModeProvider>
                   <Navbar />
+                  <AnnouncementBanner />
                   <RoleSwitcher />
                   <ErrorBoundary>
                     {children}
@@ -53,6 +55,7 @@ export default function RootLayout({
               ) : (
                 <>
                   <Navbar />
+                  <AnnouncementBanner />
                   <RoleSwitcher />
                   <ErrorBoundary>
                     {children}

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+
+interface Announcement {
+  id: string;
+  message: string;
+  start_time: string;
+  end_time: string | null;
+}
+
+export default function AnnouncementBanner() {
+  const [announcement, setAnnouncement] = useState<Announcement | null>(null);
+  const supabase = createClientComponentClient();
+
+  useEffect(() => {
+    const now = new Date().toISOString();
+    supabase
+      .from('announcements')
+      .select('*')
+      .lte('start_time', now)
+      .or(`end_time.is.null,end_time.gt.${now}`)
+      .order('start_time', { ascending: false })
+      .limit(1)
+      .single()
+      .then(({ data }) => {
+        if (data) setAnnouncement(data as Announcement);
+      });
+  }, [supabase]);
+
+  if (!announcement) return null;
+  return (
+    <div className="bg-blue-600 text-white text-center py-2 px-4 text-sm">
+      {announcement.message}
+    </div>
+  );
+}

--- a/supabase/migrations/005_announcement_system.sql
+++ b/supabase/migrations/005_announcement_system.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS announcements (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  message text NOT NULL,
+  start_time timestamp with time zone NOT NULL,
+  end_time timestamp with time zone,
+  created_at timestamp with time zone DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS announcements_active_idx
+  ON announcements (start_time, end_time);


### PR DESCRIPTION
## Summary
- implement sitewide AnnouncementBanner with Supabase data
- display the banner in app layout
- add migration for announcements table
- document in CHANGELOG

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated
- [ ] I have reviewed security implications

------
https://chatgpt.com/codex/tasks/task_e_6868826284b08323904762e54b44800f