### PR TITLE
Implement basic partner API and tenant schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ SALES_ENABLED=true
 # App Settings
 NEXT_PUBLIC_APP_URL=http://localhost:3000  # https://myroofgenius.com in production
 
+# Partner API access
+PARTNER_API_KEY=sk_partner_[...]
+
 # === OPTIONAL ===
 
 # Monitoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 - Sitewide announcement banner with Supabase-backed announcements.
 - License key management and PDF invoice generation for orders.
+- Partner API endpoint for tenant product queries.

--- a/docs/API.md
+++ b/docs/API.md
@@ -103,6 +103,22 @@ Download a purchased file using a secure one-time token.
 
 Tracks user actions for analytics.
 
+### Partner Products
+
+**GET** `/api/partner/products?tenant=<tenant_id>`
+
+Returns the active product list for a specific tenant. Requires an `x-api-key` header matching `PARTNER_API_KEY`.
+
+Example response:
+
+```json
+{
+  "products": [
+    {"id": "abc", "name": "Pro Toolkit"}
+  ]
+}
+```
+
 ### Error Responses
 
 Errors include a JSON message and HTTP status codes, e.g.:

--- a/supabase/migrations/007_multi_tenant.sql
+++ b/supabase/migrations/007_multi_tenant.sql
@@ -1,0 +1,25 @@
+-- Multi-tenant SaaS support
+CREATE TABLE IF NOT EXISTS tenants (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  name text NOT NULL,
+  subdomain text UNIQUE NOT NULL,
+  logo_url text,
+  theme jsonb,
+  support_email text,
+  created_at timestamp with time zone DEFAULT timezone('utc', now())
+);
+
+ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS tenant_id uuid REFERENCES tenants(id);
+ALTER TABLE products ADD COLUMN IF NOT EXISTS tenant_id uuid REFERENCES tenants(id);
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS tenant_id uuid REFERENCES tenants(id);
+ALTER TABLE support_tickets ADD COLUMN IF NOT EXISTS tenant_id uuid REFERENCES tenants(id);
+
+CREATE INDEX IF NOT EXISTS idx_user_profiles_tenant ON user_profiles(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_products_tenant ON products(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_orders_tenant ON orders(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_support_tickets_tenant ON support_tickets(tenant_id);
+
+-- Row level security to enforce tenant isolation on products
+ALTER TABLE products ENABLE ROW LEVEL SECURITY;
+CREATE POLICY IF NOT EXISTS "Tenant products" ON products
+  USING (tenant_id = auth.jwt() ->> 'tenant_id');

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -1,5 +1,8 @@
 import pytest
 from fastapi.testclient import TestClient
+import sys, os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 from backend.main import app
 from backend.services.fulfillment import FulfillmentService
 from unittest.mock import Mock, patch

--- a/tests/api/test_partner_api.py
+++ b/tests/api/test_partner_api.py
@@ -1,0 +1,37 @@
+import os
+import importlib
+from fastapi.testclient import TestClient
+from unittest import mock
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+os.environ["PARTNER_API_KEY"] = "testkey"
+
+# Reload module to pick up env var
+main = importlib.reload(importlib.import_module("backend.main"))
+client = TestClient(main.app)
+
+class DummyClient:
+    def table(self, name):
+        assert name == "products"
+        return self
+    def select(self, *args, **kwargs):
+        return self
+    def eq(self, *args, **kwargs):
+        return self
+    def execute(self):
+        return type("Res", (), {"data": [{"id": "p1"}]})
+
+def test_partner_products_auth():
+    resp = client.get("/api/partner/products?tenant=t1")
+    assert resp.status_code == 401
+
+def test_partner_products_success(monkeypatch):
+    monkeypatch.setattr(main, "supabase_admin", DummyClient())
+    resp = client.get(
+        "/api/partner/products?tenant=t1",
+        headers={"x-api-key": "testkey"}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"products": [{"id": "p1"}]}


### PR DESCRIPTION
## Summary
- add multi-tenant migration and policy
- expose `/api/partner/products` endpoint
- document partner API usage
- include new PARTNER_API_KEY example
- add tests loading backend module correctly

## Testing
- `npm test`
- `pytest` *(fails: 2 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6868945e2b508323b14b82dd10881800