### PR TITLE
Implement universal search endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Sitewide announcement banner with Supabase-backed announcements.
 - License key management and PDF invoice generation for orders.
 - Partner API endpoint for tenant product queries.
+- Universal search endpoint and search bar added.

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ from .prompt_service import (
     delete_prompt,
 )
 from .services.fulfillment import FulfillmentService
+from .services.search import search_products
 
 sentry_sdk.init(dsn=os.getenv("SENTRY_DSN"))
 
@@ -202,3 +203,15 @@ async def partner_products(request: Request, tenant: str):
         .execute()
     )
     return {"products": data.data or []}
+
+
+@app.post("/api/search")
+async def universal_search(data: dict):
+    """Basic search across products"""
+    query = data.get("query")
+    if not query:
+        raise HTTPException(status_code=400, detail="query required")
+    if not supabase_admin:
+        raise HTTPException(status_code=500, detail="supabase not configured")
+    results = search_products(supabase_admin, query)
+    return {"results": results}

--- a/backend/services/search.py
+++ b/backend/services/search.py
@@ -1,0 +1,15 @@
+from typing import List, Dict
+from supabase import Client
+
+
+def search_products(supabase: Client, query: str) -> List[Dict]:
+    """Simple full-text search on the products table"""
+    if not supabase:
+        return []
+    res = (
+        supabase.table("products")
+        .select("id,name,description")
+        .ilike("name", f"%{query}%")
+        .execute()
+    )
+    return res.data or []

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,7 +1,12 @@
+import SearchBar from './SearchBar';
+
 export default function Header() {
   return (
     <header className="w-full px-6 py-4 flex items-center justify-between border-b">
       <span className="text-lg font-semibold">MyRoofGenius</span>
+      <div className="w-48">
+        <SearchBar />
+      </div>
     </header>
   );
 }

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,46 @@
+'use client'
+import { useState } from 'react'
+
+export default function SearchBar() {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<{id: string; name: string; description: string}[]>([])
+
+  const search = async () => {
+    if (!query) return
+    try {
+      const res = await fetch('/api/search', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({query})
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setResults(data.results)
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return (
+    <div className="relative">
+      <input
+        type="text"
+        value={query}
+        onChange={(e)=>setQuery(e.target.value)}
+        onKeyDown={(e)=>{ if(e.key==='Enter') search() }}
+        placeholder="Search..."
+        className="border px-2 py-1 rounded"
+      />
+      {results.length>0 && (
+        <ul className="absolute bg-white border mt-1 w-full z-10 max-h-64 overflow-y-auto">
+          {results.map(r=> (
+            <li key={r.id} className="px-2 py-1 hover:bg-gray-100 text-sm">
+              {r.name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -133,3 +133,13 @@ Errors include a JSON message and HTTP status codes, e.g.:
 - General API: 1000 requests per hour.
 
 Exceeding limits returns HTTP 429.
+
+### Universal Search
+
+**POST** `/api/search`
+
+Searches across public product content. Returns matching product IDs, names, and descriptions.
+
+- **Request Body:** `{ "query": "search text" }`
+- **Response:** `{ "results": [ {"id": "p1", "name": "Item", "description": "..."} ] }`
+

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -1,0 +1,23 @@
+import os
+import importlib
+from fastapi.testclient import TestClient
+from unittest import mock
+
+os.environ['NEXT_PUBLIC_SUPABASE_URL'] = 'http://localhost'
+os.environ['SUPABASE_SERVICE_ROLE_KEY'] = 'key'
+
+main = importlib.reload(importlib.import_module('backend.main'))
+client = TestClient(main.app)
+
+
+def test_search_missing_query():
+    resp = client.post('/api/search', json={})
+    assert resp.status_code == 400
+
+
+def test_search_results(monkeypatch):
+    monkeypatch.setattr(main, 'supabase_admin', mock.Mock())
+    monkeypatch.setattr(main, 'search_products', lambda c, q: [{'id': '1', 'name': 'Test', 'description': 'd'}])
+    resp = client.post('/api/search', json={'query': 'test'})
+    assert resp.status_code == 200
+    assert resp.json() == {'results': [{'id': '1', 'name': 'Test', 'description': 'd'}]}


### PR DESCRIPTION
## Summary
- add new `/api/search` route in FastAPI backend
- implement `search_products` helper
- expose simple search bar in header for quick access
- document new API endpoint
- add basic tests for search

## Testing
- `npm test`
- `pytest -q` *(fails: order fulfillment tests failing due to webhook & download endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_686896947e408323b24235a299607ef8