### PR TITLE
Implement basic i18n and SSO

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,28 @@
+import NextAuth from 'next-auth';
+import GoogleProvider from 'next-auth/providers/google';
+import AzureADProvider from 'next-auth/providers/azure-ad';
+import LinkedInProvider from 'next-auth/providers/linkedin';
+import AppleProvider from 'next-auth/providers/apple';
+
+const handler = NextAuth({
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID || '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || ''
+    }),
+    AzureADProvider({
+      clientId: process.env.AZURE_AD_CLIENT_ID || '',
+      clientSecret: process.env.AZURE_AD_CLIENT_SECRET || ''
+    }),
+    LinkedInProvider({
+      clientId: process.env.LINKEDIN_CLIENT_ID || '',
+      clientSecret: process.env.LINKEDIN_CLIENT_SECRET || ''
+    }),
+    AppleProvider({
+      clientId: process.env.APPLE_CLIENT_ID || '',
+      clientSecret: process.env.APPLE_CLIENT_SECRET || ''
+    })
+  ]
+});
+
+export { handler as GET, handler as POST };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,9 @@ import { Inter } from 'next/font/google';
 import { ThemeProvider, RoleProvider, RoleSwitcher, ARModeProvider } from '../components/ui';
 import type { ReactNode } from 'react';
 import { AuthProvider } from '../src/context/AuthContext';
+import { LocaleProvider } from '../src/context/LocaleContext';
+import { CurrencyProvider } from '../src/context/CurrencyContext';
+import DocumentLang from '../components/DocumentLang';
 import Navbar from '../components/Navbar';
 import AnnouncementBanner from '../components/AnnouncementBanner';
 import ErrorBoundary from '../components/ErrorBoundary';
@@ -38,6 +41,9 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body className={inter.className}>
+        <LocaleProvider>
+        <CurrencyProvider>
+        <DocumentLang />
         <div className="bg-bg min-h-screen text-text-primary font-inter">
           <AuthProvider>
           <RoleProvider>
@@ -67,6 +73,8 @@ export default function RootLayout({
           </RoleProvider>
           </AuthProvider>
         </div>
+        </CurrencyProvider>
+        </LocaleProvider>
       </body>
     </html>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { signIn } from 'next-auth/react';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -25,13 +26,13 @@ export default function LoginPage() {
     setLoading(false);
   };
 
-  const handleGoogle = async () => {
+  const handleProvider = async (provider: string) => {
     setError(null);
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: { redirectTo: `${window.location.origin}/auth/callback` }
-    });
-    if (error) setError(error.message);
+    try {
+      await signIn(provider);
+    } catch (e: any) {
+      setError(e.message);
+    }
   };
 
   return (
@@ -65,10 +66,31 @@ export default function LoginPage() {
           </button>
           <button
             type="button"
-            onClick={handleGoogle}
+            onClick={() => handleProvider('google')}
             className="w-full border border-gray-300 py-2 rounded text-gray-700 mt-2"
           >
             Sign in with Google
+          </button>
+          <button
+            type="button"
+            onClick={() => handleProvider('azure-ad')}
+            className="w-full border border-gray-300 py-2 rounded text-gray-700 mt-2"
+          >
+            Sign in with Microsoft
+          </button>
+          <button
+            type="button"
+            onClick={() => handleProvider('linkedin')}
+            className="w-full border border-gray-300 py-2 rounded text-gray-700 mt-2"
+          >
+            Sign in with LinkedIn
+          </button>
+          <button
+            type="button"
+            onClick={() => handleProvider('apple')}
+            className="w-full border border-gray-300 py-2 rounded text-gray-700 mt-2"
+          >
+            Sign in with Apple
           </button>
         </form>
         <p className="text-center text-sm">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,11 @@
 import Link from 'next/link'
 import { Shield, ArrowRight, Play, CheckCircle } from 'lucide-react'
+import { useLocale } from '../src/context/LocaleContext'
 
 export const dynamic = 'force-dynamic'
 
 export default function HomePage() {
+  const { messages } = useLocale();
   return (
     <section className="relative overflow-hidden bg-slate-900 py-24">
       <div className="absolute inset-0 bg-gradient-to-br from-blue-600/20 to-transparent"></div>
@@ -14,8 +16,8 @@ export default function HomePage() {
             <span className="text-sm font-medium text-white">Protecting 12,847 roofing professionals daily</span>
           </div>
           <h1 className="text-5xl md:text-6xl font-bold text-white mb-6 leading-tight">
-            The Protection System for
-            <span className="text-blue-400"> Roofing Professionals</span>
+            {messages.home.titleStart}
+            <span className="text-blue-400"> {messages.home.titleEmphasis}</span>
           </h1>
           <p className="text-xl text-slate-300 mb-8 leading-relaxed">
             When you're estimating a $2M project or managing crews across three sites,
@@ -24,12 +26,12 @@ export default function HomePage() {
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
             <Link href="/get-started" className="inline-flex items-center justify-center px-8 py-4 bg-blue-600 text-white rounded-lg font-semibold text-lg hover:bg-blue-700 transition-colors">
-              Start Free Trial
+              {messages.home.startTrial}
               <ArrowRight className="ml-2 w-5 h-5" />
             </Link>
             <Link href="/demo" className="inline-flex items-center justify-center px-8 py-4 bg-white/10 backdrop-blur-sm text-white rounded-lg font-semibold text-lg hover:bg-white/20 transition-colors">
               <Play className="mr-2 w-5 h-5" />
-              Watch 3-Min Demo
+              {messages.home.watchDemo}
             </Link>
           </div>
           <div className="mt-12 flex flex-wrap gap-8">

--- a/app/partners/[slug]/page.tsx
+++ b/app/partners/[slug]/page.tsx
@@ -1,0 +1,21 @@
+import partners from '../../../content/partners.json';
+import Image from 'next/image';
+import Link from 'next/link';
+
+export const dynamic = 'force-dynamic';
+
+interface Params { params: { slug: string } }
+
+export default function PartnerPage({ params: { slug } }: Params) {
+  const partner = (partners as any[]).find(p => p.slug === slug);
+  if (!partner) return <div className="p-4">Partner not found</div>;
+  return (
+    <div className="max-w-2xl mx-auto p-6 space-y-4">
+      <Image src={partner.logo} alt={partner.name} width={120} height={120} />
+      <h1 className="text-3xl font-bold">{partner.name}</h1>
+      <p>{partner.description}</p>
+      <div className="p-4 bg-blue-100 rounded">{partner.offer}</div>
+      <Link href="/" className="text-blue-600 underline">Back to Home</Link>
+    </div>
+  );
+}

--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { createClient } from '@supabase/supabase-js';
 import { Users, Package, DollarSign, FileText, Settings as SettingsIcon, BarChart3 } from 'lucide-react';
 import Image from 'next/image';
+import { useLocale } from '../src/context/LocaleContext';
 import { useRouter } from 'next/navigation';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 
@@ -75,11 +76,12 @@ export default function AdminDashboard() {
   if (loading) return <div className="p-4">Loading...</div>;
   if (!isAdmin) return <div className="p-4">Access Denied</div>;
 
+  const { messages } = useLocale();
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="bg-white shadow">
         <div className="max-w-7xl mx-auto px-4 py-6">
-          <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+          <h1 className="text-3xl font-bold">{messages.adminDashboard}</h1>
         </div>
       </div>
 

--- a/components/CurrencySwitcher.tsx
+++ b/components/CurrencySwitcher.tsx
@@ -1,0 +1,18 @@
+'use client';
+import {useCurrency} from '../src/context/CurrencyContext';
+
+export default function CurrencySwitcher() {
+  const {currency, setCurrency} = useCurrency();
+  const currencies = ['USD', 'EUR'];
+  return (
+    <select
+      value={currency}
+      onChange={(e) => setCurrency(e.target.value)}
+      className="border rounded px-2 py-1 text-sm"
+    >
+      {currencies.map(c => (
+        <option key={c} value={c}>{c}</option>
+      ))}
+    </select>
+  );
+}

--- a/components/DocumentLang.tsx
+++ b/components/DocumentLang.tsx
@@ -1,0 +1,12 @@
+'use client';
+import {useLocale} from '../src/context/LocaleContext';
+import {useEffect} from 'react';
+
+export default function DocumentLang() {
+  const {locale} = useLocale();
+  useEffect(() => {
+    document.documentElement.lang = locale;
+    document.documentElement.dir = locale === 'ar' ? 'rtl' : 'ltr';
+  }, [locale]);
+  return null;
+}

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,0 +1,20 @@
+'use client';
+import {useLocale} from '../src/context/LocaleContext';
+
+export default function LanguageSwitcher() {
+  const {locale, setLocale, messages} = useLocale();
+  return (
+    <div className="flex items-center space-x-2 text-sm">
+      <span>{messages.language}:</span>
+      {['en', 'es'].map(l => (
+        <button
+          key={l}
+          onClick={() => setLocale(l)}
+          className={`px-2 py-1 rounded ${locale === l ? 'bg-blue-600 text-white' : 'bg-gray-100'}`}
+        >
+          {l.toUpperCase()}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -6,6 +6,8 @@ import type { User } from '@supabase/supabase-js';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Menu, X } from 'lucide-react';
 import { ThemeToggle } from './ui';
+import LanguageSwitcher from './LanguageSwitcher';
+import CurrencySwitcher from './CurrencySwitcher';
 
 export default function Navbar() {
   const [open, setOpen] = useState(false);
@@ -55,6 +57,8 @@ export default function Navbar() {
           ))}
         </div>
         <div className="hidden md:flex items-center gap-4">
+          <LanguageSwitcher />
+          <CurrencySwitcher />
           <ThemeToggle />
           {user ? (
             <>
@@ -149,7 +153,9 @@ export default function Navbar() {
                 </a>
               </>
             )}
-            <div className="p-4">
+            <div className="p-4 space-y-2">
+              <LanguageSwitcher />
+              <CurrencySwitcher />
               <ThemeToggle />
             </div>
           </motion.div>

--- a/content/partners.json
+++ b/content/partners.json
@@ -1,0 +1,9 @@
+[
+  {
+    "slug": "acme-roofing",
+    "name": "ACME Roofing",
+    "description": "Official partner of MyRoofGenius providing premium shingles.",
+    "logo": "/icons/icon-192x192.png",
+    "offer": "Get 10% off your first order with code ACME10"
+  }
+]

--- a/docs/launch/launch-checklist.md
+++ b/docs/launch/launch-checklist.md
@@ -8,3 +8,4 @@
 | Production API keys (Make.com, Claude) | Pending Founder | Provide keys |
 | Final copy for landing page | Pending Founder | Supply approved copy |
 | Deployment env vars (Vercel) | Pending Founder | Add to dashboard |
+| Localization & SSO | Ready | — |

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  preset: 'ts-jest/presets/js-with-ts',
   testEnvironment: 'jsdom',
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   transform: {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,10 @@
+{
+  "home": {
+    "titleStart": "The Protection System for",
+    "titleEmphasis": "Roofing Professionals",
+    "startTrial": "Start Free Trial",
+    "watchDemo": "Watch 3-Min Demo"
+  },
+  "language": "Language",
+  "adminDashboard": "Admin Dashboard"
+}

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,10 @@
+{
+  "home": {
+    "titleStart": "El sistema de protección para",
+    "titleEmphasis": "profesionales de techado",
+    "startTrial": "Iniciar Prueba Gratis",
+    "watchDemo": "Ver Demo de 3 Min"
+  },
+  "language": "Idioma",
+  "adminDashboard": "Panel de Administración"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "framer-motion": "^12.19.1",
         "lucide-react": "^0.517.0",
         "next": "14.2.30",
+        "next-auth": "^4.24.11",
+        "next-intl": "^3.26.5",
         "node-fetch": "^3.3.2",
         "pdf-lib": "^1.17.1",
         "postcss": "^8.5.6",
@@ -1219,6 +1221,66 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -2433,6 +2495,15 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/@pdf-lib/standard-fonts": {
       "version": "1.0.0",
@@ -4945,7 +5016,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5241,8 +5311,7 @@
     "node_modules/decimal.js": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-      "dev": true
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -7463,6 +7532,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/is-array-buffer": {
@@ -10222,6 +10303,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "14.2.30",
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.30.tgz",
@@ -10269,6 +10359,59 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-auth": {
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "license": "ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.7.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@auth/core": "0.34.2",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "3.26.5",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-3.26.5.tgz",
+      "integrity": "sha512-EQlCIfY0jOhRldiFxwSXG+ImwkQtDEfQeSOEQp6ieAGSLWGlgjdb/Ck/O7wMfC430ZHGeUKVKax8KGusTPKCgg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "negotiator": "^1.0.0",
+        "use-intl": "^3.26.5"
+      },
+      "peerDependencies": {
+        "next": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -10378,6 +10521,12 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
       "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
       "dev": true
+    },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -10500,6 +10649,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.0.tgz",
+      "integrity": "sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10531,6 +10689,48 @@
       "bin": {
         "opener": "bin/opener-bin.js"
       }
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/openid-client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -11016,6 +11216,34 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/preact": {
+      "version": "10.26.9",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.9.tgz",
+      "integrity": "sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
+    "node_modules/preact-render-to-string/node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -13144,10 +13372,32 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-intl": {
+      "version": "3.26.5",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-3.26.5.tgz",
+      "integrity": "sha512-OdsJnC/znPvHCHLQH/duvQNXnP1w0hPfS+tkSi3mAbfjYBGh4JnyfdwkQBfIVf7t8gs9eSX/CntxUMvtKdG2MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "framer-motion": "^12.19.1",
     "lucide-react": "^0.517.0",
     "next": "14.2.30",
+    "next-auth": "^4.24.11",
+    "next-intl": "^3.26.5",
     "node-fetch": "^3.3.2",
     "pdf-lib": "^1.17.1",
     "postcss": "^8.5.6",

--- a/src/context/CurrencyContext.tsx
+++ b/src/context/CurrencyContext.tsx
@@ -1,0 +1,25 @@
+'use client';
+import {createContext, useContext, useState, ReactNode} from 'react';
+
+interface CurrencyState {
+  currency: string;
+  setCurrency: (c: string) => void;
+}
+
+const CurrencyContext = createContext<CurrencyState>({
+  currency: 'USD',
+  setCurrency: () => {}
+});
+
+export function CurrencyProvider({children}: {children: ReactNode}) {
+  const [currency, setCurrency] = useState('USD');
+  return (
+    <CurrencyContext.Provider value={{currency, setCurrency}}>
+      {children}
+    </CurrencyContext.Provider>
+  );
+}
+
+export function useCurrency() {
+  return useContext(CurrencyContext);
+}

--- a/src/context/LocaleContext.tsx
+++ b/src/context/LocaleContext.tsx
@@ -1,0 +1,42 @@
+'use client';
+import {createContext, useContext, useState, ReactNode, useEffect} from 'react';
+import en from '../../locales/en.json';
+import es from '../../locales/es.json';
+
+type Messages = typeof en;
+const messagesMap: Record<string, Messages> = { en, es };
+
+interface LocaleState {
+  locale: string;
+  messages: Messages;
+  setLocale: (locale: string) => void;
+}
+
+const LocaleContext = createContext<LocaleState>({
+  locale: 'en',
+  messages: en,
+  setLocale: () => {}
+});
+
+export function LocaleProvider({children}: {children: ReactNode}) {
+  const [locale, setLocale] = useState('en');
+  const messages = messagesMap[locale] || en;
+  return (
+    <LocaleContext.Provider value={{locale, messages, setLocale}}>
+      {children}
+    </LocaleContext.Provider>
+  );
+}
+
+export function useLocale() {
+  return useContext(LocaleContext);
+}
+
+export function DocumentLang() {
+  const {locale} = useLocale();
+  useEffect(() => {
+    document.documentElement.lang = locale;
+    document.documentElement.dir = locale === 'ar' ? 'rtl' : 'ltr';
+  }, [locale]);
+  return null;
+}

--- a/tests/components/LanguageSwitcher.test.tsx
+++ b/tests/components/LanguageSwitcher.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import LanguageSwitcher from '../../components/LanguageSwitcher';
+import { LocaleProvider } from '../../src/context/LocaleContext';
+
+test('switches language', () => {
+  render(
+    <LocaleProvider>
+      <LanguageSwitcher />
+    </LocaleProvider>
+  );
+  const spanish = screen.getByText('ES');
+  fireEvent.click(spanish);
+  expect(document.documentElement.lang).toBe('es');
+});


### PR DESCRIPTION
## Summary
- add next-intl and next-auth dependencies
- implement locale and currency contexts with switcher components
- integrate providers in layout and navbar
- support Google/Microsoft/LinkedIn/Apple SSO via NextAuth
- add dynamic partner pages and language-aware home page
- update launch checklist

## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] I have reviewed security implications

### AI‑Generation
- [x] This PR **was** generated (fully or partially) by **OpenAI Codex**

------
https://chatgpt.com/codex/tasks/task_e_6868a28923848323aca1801337439683