### PR TITLE
Add accent color picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Partner API endpoint for tenant product queries.
 - Universal search endpoint and search bar added.
 - Developer portal API key endpoints.
+- Accent color picker lets users personalize the UI theme.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ npm test
 npm run build
 ```
 
+### Theme Accent
+Pick a custom accent color from the Navbar color picker. Your choice is persisted in localStorage.
+
 ## 📁 Project Structure
 
 ```

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,7 @@
   }
 
   :root {
+    --accent: 94 92 230;
     /* Protection Status Colors */
     --color-protected: 34 197 94;
     --color-warning: 251 146 60;

--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -73,10 +73,10 @@ export default function AdminDashboard() {
     }
   }
 
+  const { messages } = useLocale();
+
   if (loading) return <div className="p-4">Loading...</div>;
   if (!isAdmin) return <div className="p-4">Access Denied</div>;
-
-  const { messages } = useLocale();
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="bg-white shadow">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -5,7 +5,7 @@ import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import type { User } from '@supabase/supabase-js';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Menu, X } from 'lucide-react';
-import { ThemeToggle } from './ui';
+import { ThemeToggle, AccentColorPicker } from './ui';
 import LanguageSwitcher from './LanguageSwitcher';
 import CurrencySwitcher from './CurrencySwitcher';
 
@@ -60,6 +60,7 @@ export default function Navbar() {
           <LanguageSwitcher />
           <CurrencySwitcher />
           <ThemeToggle />
+          <AccentColorPicker />
           {user ? (
             <>
               {user.user_metadata?.role === 'admin' && (
@@ -157,6 +158,7 @@ export default function Navbar() {
               <LanguageSwitcher />
               <CurrencySwitcher />
               <ThemeToggle />
+              <AccentColorPicker />
             </div>
           </motion.div>
         )}

--- a/components/ui/AccentColorPicker.tsx
+++ b/components/ui/AccentColorPicker.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useTheme } from './ThemeProvider';
+
+export default function AccentColorPicker() {
+  const { accent, setAccent } = useTheme();
+  return (
+    <input
+      type="color"
+      aria-label="Accent color"
+      value={accent}
+      onChange={e => setAccent(e.target.value)}
+      className="w-6 h-6 p-0 border-0 bg-transparent cursor-pointer focus:outline-none"
+    />
+  );
+}

--- a/components/ui/ThemeProvider.tsx
+++ b/components/ui/ThemeProvider.tsx
@@ -2,17 +2,30 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 
 type Theme = 'dark' | 'light'
-interface ThemeCtx { theme: Theme; toggle: () => void }
+interface ThemeCtx {
+  theme: Theme
+  toggle: () => void
+  accent: string
+  setAccent: (c: string) => void
+}
 
-const ThemeContext = createContext<ThemeCtx>({ theme: 'dark', toggle: () => {} });
+const ThemeContext = createContext<ThemeCtx>({
+  theme: 'dark',
+  toggle: () => {},
+  accent: '#5e5ce6',
+  setAccent: () => {}
+});
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>('dark');
+  const [accent, setAccent] = useState('#5e5ce6');
 
   useEffect(() => {
     // Load persisted theme from localStorage if available
     const stored = localStorage.getItem('theme') as Theme | null;
     if (stored) setTheme(stored);
+    const acc = localStorage.getItem('accent');
+    if (acc) setAccent(acc);
   }, []);
 
   useEffect(() => {
@@ -26,8 +39,25 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     localStorage.setItem('theme', theme);
   }, [theme]);
 
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const hex = accent.startsWith('#') ? accent.slice(1) : accent;
+    const r = parseInt(hex.substring(0, 2), 16);
+    const g = parseInt(hex.substring(2, 4), 16);
+    const b = parseInt(hex.substring(4, 6), 16);
+    document.documentElement.style.setProperty('--accent', `${r} ${g} ${b}`);
+    localStorage.setItem('accent', accent);
+  }, [accent]);
+
   return (
-    <ThemeContext.Provider value={{ theme, toggle: () => setTheme(t => (t === 'dark' ? 'light' : 'dark')) }}>
+    <ThemeContext.Provider
+      value={{
+        theme,
+        toggle: () => setTheme(t => (t === 'dark' ? 'light' : 'dark')),
+        accent,
+        setAccent
+      }}
+    >
       {children}
     </ThemeContext.Provider>
   );

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -7,3 +7,4 @@ export { default as RoleSwitcher } from './RoleSwitcher';
 export { default as HotActions } from '../HotActions';
 export { ARModeProvider, useARMode } from './ARModeProvider';
 export { default as ARModeToggle } from './ARModeToggle';
+export { default as AccentColorPicker } from './AccentColorPicker';

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Accent color picker in Navbar to customize theme.
+
 ## v1.0.0
 - Initial commit of MyRoofGenius application.
 - Added license key system and invoice download endpoint.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,7 +11,7 @@ module.exports = {
           DEFAULT: '#121212',
           card: '#1C1C1E',
         },
-        accent: '#5E5CE6',
+        accent: 'rgb(var(--accent) / <alpha-value>)',
         text: {
           primary: '#F2F2F7',
           secondary: '#8E8E93',


### PR DESCRIPTION
## Summary
- allow dynamic accent color via CSS variable
- persist chosen accent color in ThemeProvider
- add AccentColorPicker component and integrate into Navbar
- document accent color feature in README
- update changelog entries
- fix hook order in AdminDashboard

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check` *(fails: Property 'onConflict' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6868a9c22480832389df884aff6dee29