### PR TITLE
Add cinematic modal and toast components

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import './globals.css';
 import { Inter } from 'next/font/google';
-import { ThemeProvider, RoleProvider, RoleSwitcher, ARModeProvider } from '../components/ui';
+import { ThemeProvider, RoleProvider, RoleSwitcher, ARModeProvider, ToastProvider } from '../components/ui';
 import type { ReactNode } from 'react';
 import { AuthProvider } from '../src/context/AuthContext';
 import { LocaleProvider } from '../src/context/LocaleContext';
@@ -51,6 +51,7 @@ export default function RootLayout({
           <AuthProvider>
           <RoleProvider>
             <ThemeProvider>
+              <ToastProvider>
               {arModeEnabled ? (
                 <ARModeProvider>
                   <Navbar />
@@ -72,6 +73,7 @@ export default function RootLayout({
                   {aiCopilotEnabled && <CopilotWrapper />}
                 </>
               )}
+              </ToastProvider>
             </ThemeProvider>
           </RoleProvider>
           </AuthProvider>

--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -7,6 +7,7 @@ import Image from 'next/image';
 import { useLocale } from '../src/context/LocaleContext';
 import { useRouter } from 'next/navigation';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import { Modal, useToast } from './ui';
 
 async function checkAdminAccess() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -302,6 +303,7 @@ function ProductsTab() {
 }
 
 function AddProductModal({ onClose }: { onClose: () => void }) {
+  const toast = useToast();
   const [formData, setFormData] = useState({ name: '', description: '', price: '', category: 'estimation', features: '', image_url: '' });
 
   async function handleSubmit(e: React.FormEvent) {
@@ -312,15 +314,17 @@ function AddProductModal({ onClose }: { onClose: () => void }) {
       body: JSON.stringify(formData)
     });
     if (res.ok) {
+      toast('Product added', 'success');
       onClose();
+    } else {
+      toast('Failed to add product', 'error');
     }
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-lg max-w-lg w-full p-6">
-        <h3 className="text-xl font-semibold mb-4">Add New Product</h3>
-        <form onSubmit={handleSubmit} className="space-y-4">
+    <Modal open onClose={onClose}>
+      <h3 className="text-xl font-semibold mb-4">Add New Product</h3>
+      <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1">Product Name</label>
             <input type="text" value={formData.name} onChange={e => setFormData({ ...formData, name: e.target.value })} className="w-full px-3 py-2 border rounded-lg" required />
@@ -360,8 +364,7 @@ function AddProductModal({ onClose }: { onClose: () => void }) {
             <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">Add Product</button>
           </div>
         </form>
-      </div>
-    </div>
+    </Modal>
   );
 }
 

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { ReactNode } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function Modal({ open, onClose, children }: ModalProps) {
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            initial={{ scale: 0.9, opacity: 0, y: 20 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.9, opacity: 0, y: 20 }}
+            transition={{ type: 'spring', stiffness: 200, damping: 20 }}
+            className="relative w-full max-w-lg p-6 glass rounded-xl text-white shadow-2xl"
+          >
+            <button
+              onClick={onClose}
+              className="absolute top-3 right-3 text-xl leading-none"
+            >
+              &times;
+            </button>
+            {children}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { CheckCircle, XCircle, Info } from 'lucide-react';
+
+type ToastType = 'success' | 'error' | 'info';
+interface Toast {
+  id: number;
+  type: ToastType;
+  message: string;
+}
+
+const ToastCtx = createContext<{ show: (message: string, type?: ToastType) => void } | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const show = (message: string, type: ToastType = 'info') => {
+    const id = Date.now();
+    setToasts((t) => [...t, { id, type, message }]);
+    setTimeout(() => setToasts((t) => t.filter((toast) => toast.id !== id)), 3000);
+  };
+  return (
+    <ToastCtx.Provider value={{ show }}>
+      {children}
+      <div className="fixed bottom-6 right-6 space-y-2 z-50">
+        <AnimatePresence>
+          {toasts.map((t) => (
+            <motion.div
+              key={t.id}
+              initial={{ rotateY: 90, opacity: 0 }}
+              animate={{ rotateY: 0, opacity: 1 }}
+              exit={{ rotateY: 90, opacity: 0 }}
+              className="flex items-center gap-2 px-4 py-2 rounded-lg glass text-white shadow-xl"
+            >
+              {t.type === 'success' && <CheckCircle className="w-4 h-4 text-green-400" />}
+              {t.type === 'error' && <XCircle className="w-4 h-4 text-red-400" />}
+              {t.type === 'info' && <Info className="w-4 h-4 text-blue-400" />}
+              <span>{t.message}</span>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+    </ToastCtx.Provider>
+  );
+}
+
+export const useToast = () => {
+  const ctx = useContext(ToastCtx);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx.show;
+};

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -10,3 +10,5 @@ export { default as ARModeToggle } from './ARModeToggle';
 export { default as AccentColorPicker } from './AccentColorPicker';
 export { default as AnimatedGradient } from './AnimatedGradient';
 export { default as Hero3D } from './Hero3D';
+export { ToastProvider, useToast } from './Toast';
+export { default as Modal } from './Modal';

--- a/src/features/estimation/EstimationDashboard.tsx
+++ b/src/features/estimation/EstimationDashboard.tsx
@@ -1,5 +1,7 @@
 'use client';
 import { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import Dashboard3D from '../../../components/Dashboard3D';
 import { RiskAnalysisEngine, ProjectData } from '../../utils/RiskAnalysisEngine';
 import { supabase } from '../../services/supabaseClient';
 
@@ -29,6 +31,9 @@ export default function EstimationDashboard() {
   return (
     <div className="p-6">
       <h1 className="text-2xl font-semibold mb-4">Estimation Dashboard</h1>
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mb-6">
+        <Dashboard3D />
+      </motion.div>
       {loading && <p className="mb-4">Loading project...</p>}
       <div className="space-y-4">
         <div>
@@ -46,11 +51,16 @@ export default function EstimationDashboard() {
         <div className="mt-6 space-y-2">
           <h2 className="text-xl font-semibold">Identified Risks</h2>
           {risks.map(risk => (
-            <div key={risk.type} className="border p-2 rounded bg-white/10 backdrop-blur-sm">
+            <motion.div
+              key={risk.type}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="border p-2 rounded bg-white/10 backdrop-blur-sm"
+            >
               <p className="font-medium">{risk.type}</p>
               <p>Probability: {(risk.probability * 100).toFixed(0)}%</p>
               <p>Impact: ${risk.impactLow.toFixed(0)} - ${risk.impactHigh.toFixed(0)}</p>
-            </div>
+            </motion.div>
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- create reusable `Modal` component with framer-motion glassmorphic style
- create `ToastProvider` and `useToast` hook with card flip animation
- integrate toast provider into root layout
- update admin product modal to use Modal and toast
- enhance estimation dashboard with 3D model and animated risk items

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68696ef0324883238ca0f495b5ef1e84