### PR TITLE
Add confetti toast and parallax modal

### DIFF
--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,6 +1,6 @@
-'use client';
-import { ReactNode } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+"use client";
+import { ReactNode, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 
 interface ModalProps {
   open: boolean;
@@ -9,6 +9,7 @@ interface ModalProps {
 }
 
 export default function Modal({ open, onClose, children }: ModalProps) {
+  const [pos, setPos] = useState({ x: 0, y: 0 });
   return (
     <AnimatePresence>
       {open && (
@@ -22,7 +23,15 @@ export default function Modal({ open, onClose, children }: ModalProps) {
             initial={{ scale: 0.9, opacity: 0, y: 20 }}
             animate={{ scale: 1, opacity: 1, y: 0 }}
             exit={{ scale: 0.9, opacity: 0, y: 20 }}
-            transition={{ type: 'spring', stiffness: 200, damping: 20 }}
+            transition={{ type: "spring", stiffness: 200, damping: 20 }}
+            onMouseMove={(e) => {
+              const r = e.currentTarget.getBoundingClientRect();
+              setPos({
+                x: (e.clientX - r.left - r.width / 2) / r.width,
+                y: (e.clientY - r.top - r.height / 2) / r.height,
+              });
+            }}
+            style={{ rotateX: pos.y * -10, rotateY: pos.x * 10 }}
             className="relative w-full max-w-lg p-6 glass rounded-xl text-white shadow-2xl"
           >
             <button

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,23 +1,31 @@
-'use client';
-import { createContext, useContext, useState, ReactNode } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
-import { CheckCircle, XCircle, Info } from 'lucide-react';
+"use client";
+import { createContext, useContext, useState, ReactNode } from "react";
+import { useConfetti } from "../../hooks/use-confetti";
+import { AnimatePresence, motion } from "framer-motion";
+import { CheckCircle, XCircle, Info } from "lucide-react";
 
-type ToastType = 'success' | 'error' | 'info';
+type ToastType = "success" | "error" | "info";
 interface Toast {
   id: number;
   type: ToastType;
   message: string;
 }
 
-const ToastCtx = createContext<{ show: (message: string, type?: ToastType) => void } | null>(null);
+const ToastCtx = createContext<{
+  show: (message: string, type?: ToastType) => void;
+} | null>(null);
 
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
-  const show = (message: string, type: ToastType = 'info') => {
+  const triggerConfetti = useConfetti();
+  const show = (message: string, type: ToastType = "info") => {
     const id = Date.now();
     setToasts((t) => [...t, { id, type, message }]);
-    setTimeout(() => setToasts((t) => t.filter((toast) => toast.id !== id)), 3000);
+    setTimeout(
+      () => setToasts((t) => t.filter((toast) => toast.id !== id)),
+      3000,
+    );
+    if (type === "success") triggerConfetti();
   };
   return (
     <ToastCtx.Provider value={{ show }}>
@@ -32,9 +40,13 @@ export function ToastProvider({ children }: { children: ReactNode }) {
               exit={{ rotateY: 90, opacity: 0 }}
               className="flex items-center gap-2 px-4 py-2 rounded-lg glass text-white shadow-xl"
             >
-              {t.type === 'success' && <CheckCircle className="w-4 h-4 text-green-400" />}
-              {t.type === 'error' && <XCircle className="w-4 h-4 text-red-400" />}
-              {t.type === 'info' && <Info className="w-4 h-4 text-blue-400" />}
+              {t.type === "success" && (
+                <CheckCircle className="w-4 h-4 text-green-400" />
+              )}
+              {t.type === "error" && (
+                <XCircle className="w-4 h-4 text-red-400" />
+              )}
+              {t.type === "info" && <Info className="w-4 h-4 text-blue-400" />}
               <span>{t.message}</span>
             </motion.div>
           ))}
@@ -46,6 +58,6 @@ export function ToastProvider({ children }: { children: ReactNode }) {
 
 export const useToast = () => {
   const ctx = useContext(ToastCtx);
-  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
   return ctx.show;
 };

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,19 +1,24 @@
 # Changelog
 
 ## Unreleased
+
 - Accent color picker in Navbar to customize theme.
 - Interactive 3D dashboard model and card tilt effects.
+- Confetti-enhanced toast notifications and parallax modal motion.
 
 ## v1.0.0
+
 - Initial commit of MyRoofGenius application.
 - Added license key system and invoice download endpoint.
 
 ## Sprint 009
+
 - Repository cleanup scripts and dependency audit.
 - ESLint rules and Husky hooks added.
 - Documentation updates and environment validation.
 
 ## Sprint 012
+
 - Member dashboard enhancements with favorites and support messaging.
 - Google sign-in added to authentication flow.
 - Admin revenue chart now uses Recharts.

--- a/hooks/use-confetti.ts
+++ b/hooks/use-confetti.ts
@@ -1,0 +1,13 @@
+import { useCallback } from "react";
+
+export function useConfetti() {
+  return useCallback(async () => {
+    const mod = await import("canvas-confetti");
+    const confetti = mod.default || mod;
+    confetti({
+      particleCount: 100,
+      spread: 70,
+      origin: { y: 0.6 },
+    });
+  }, []);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@supabase/supabase-js": "^2.50.1",
         "@tailwindcss/forms": "^0.5.7",
         "autoprefixer": "^10.4.21",
+        "canvas-confetti": "^1.9.2",
         "clsx": "^2.1.1",
         "dotenv": "^16.5.0",
         "framer-motion": "^12.19.1",
@@ -4988,6 +4989,16 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.2.tgz",
+      "integrity": "sha512-6Xi7aHHzKwxZsem4mCKoqP6YwUG3HamaHHAlz1hTNQPCqXhARFpSXnkC9TWlahHY5CG6hSL5XexNjxK8irVErg==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@supabase/supabase-js": "^2.50.1",
     "@tailwindcss/forms": "^0.5.7",
     "autoprefixer": "^10.4.21",
+    "canvas-confetti": "^1.9.2",
     "clsx": "^2.1.1",
     "dotenv": "^16.5.0",
     "framer-motion": "^12.19.1",


### PR DESCRIPTION
## Summary
- add `useConfetti` hook using `canvas-confetti`
- trigger confetti on success toasts
- add parallax hover effect to Modal
- document changes in CHANGELOG

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6869a85df1048323b9f543ab71d3db22