### PR TITLE
Fix error/404 pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Universal search endpoint and search bar added.
 - Developer portal API key endpoints.
 - Accent color picker lets users personalize the UI theme.
+- Tweaked error and not-found pages for compatibility with Next.js routing.

--- a/README.md
+++ b/README.md
@@ -153,3 +153,4 @@ Legacy sprint docs can be archived by running `scripts/archive-preV1.sh`.
 - [QA Smoke Test Guide](docs/launch/production-qa-smoke-test.md)
 - [Launch Checklist](docs/launch/launch-checklist.md)
 - [Developer Portal Guide](docs/DEVELOPER_PORTAL.md)
+\n### Maintenance\n- Minor cleanup of error handling routes.

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,5 +1,4 @@
 'use client';
-export const dynamic = 'force-dynamic';
 import { useEffect } from 'react';
 import { sendAlert } from './lib/notify';
 

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,5 +1,4 @@
 'use client';
-export const dynamic = 'force-dynamic';
 
 export default function NotFound() {
   return (


### PR DESCRIPTION
## Summary
- drop dynamic flags from error and not-found pages
- update changelog and README docs

## Remaining issues
- `next build` fails: `Error: <Html> should not be imported outside of pages/_document.` when prerendering `/404` and `/500`.


------
https://chatgpt.com/codex/tasks/task_e_6869f2b6cdf48323b5ae4a28850c41e1