### PR TITLE
Fix broken tool links and add Get Started page

### DIFF
--- a/app/get-started/page.tsx
+++ b/app/get-started/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+import Link from 'next/link'
+
+export default function GetStarted() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center p-8">
+      <div className="max-w-xl text-center">
+        <h1 className="text-4xl font-bold text-slate-900 mb-4">Start Your Free Trial</h1>
+        <p className="text-lg text-slate-700 mb-6">Create your account to access professional roofing calculators and templates.</p>
+        <Link href="/signup" className="inline-block bg-blue-600 text-white px-8 py-3 rounded-lg font-semibold hover:bg-blue-700 transition-colors">Create Account</Link>
+        <p className="mt-4 text-sm text-slate-600">Already have an account? <Link href="/login" className="text-blue-600 underline">Sign in</Link></p>
+      </div>
+    </div>
+  )
+}

--- a/app/tools/cash-flow/page.tsx
+++ b/app/tools/cash-flow/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+import Link from 'next/link'
+
+export default function CashFlow() {
+  return (
+    <div className="min-h-screen bg-gray-50 p-8 flex items-center justify-center">
+      <div className="max-w-2xl bg-white rounded-xl shadow p-8 text-center">
+        <h1 className="text-3xl font-bold mb-4">Cash Flow Forecaster</h1>
+        <p className="text-gray-600 mb-6">Predict payment schedules and spot cash crunches 30 days in advance.</p>
+        <div className="space-y-2 mb-6 text-left">
+          <p>✓ Payment schedule modeling</p>
+          <p>✓ Weather delay impacts</p>
+          <p>✓ Multi-project view</p>
+        </div>
+        <Link href="/signup" className="px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700">Create Free Account</Link>
+      </div>
+    </div>
+  )
+}

--- a/app/tools/change-orders/page.tsx
+++ b/app/tools/change-orders/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+import Link from 'next/link'
+
+export default function ChangeOrders() {
+  return (
+    <div className="min-h-screen bg-gray-50 p-8 flex items-center justify-center">
+      <div className="max-w-2xl bg-white rounded-xl shadow p-8 text-center">
+        <h1 className="text-3xl font-bold mb-4">Change Order Calculator</h1>
+        <p className="text-gray-600 mb-6">Price project changes fairly while protecting your margins.</p>
+        <div className="space-y-2 mb-6 text-left">
+          <p>✓ Automatic markup scaling</p>
+          <p>✓ Cumulative impact tracking</p>
+          <p>✓ Client-ready reports</p>
+        </div>
+        <Link href="/signup" className="px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700">Create Free Account</Link>
+      </div>
+    </div>
+  )
+}

--- a/app/tools/labor-estimator/page.tsx
+++ b/app/tools/labor-estimator/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+import Link from 'next/link'
+
+export default function LaborEstimator() {
+  return (
+    <div className="min-h-screen bg-gray-50 p-8 flex items-center justify-center">
+      <div className="max-w-2xl bg-white rounded-xl shadow p-8 text-center">
+        <h1 className="text-3xl font-bold mb-4">Labor Hour Estimator</h1>
+        <p className="text-gray-600 mb-6">Calculate accurate crew sizes based on real productivity data.</p>
+        <div className="space-y-2 mb-6 text-left">
+          <p>✓ Weather impact factors</p>
+          <p>✓ Crew skill adjustments</p>
+          <p>✓ Overtime calculations</p>
+        </div>
+        <Link href="/signup" className="px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700">Create Free Account</Link>
+      </div>
+    </div>
+  )
+}

--- a/app/tools/material-calculator/page.tsx
+++ b/app/tools/material-calculator/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+import Link from 'next/link'
+
+export default function MaterialCalculator() {
+  return (
+    <div className="min-h-screen bg-gray-50 p-8 flex items-center justify-center">
+      <div className="max-w-2xl bg-white rounded-xl shadow p-8 text-center">
+        <h1 className="text-3xl font-bold mb-4">Material Calculator Pro</h1>
+        <p className="text-gray-600 mb-6">Upload your roof measurements and get precise material lists with waste factors applied.</p>
+        <div className="space-y-2 mb-6 text-left">
+          <p>✓ Waste factor calculations</p>
+          <p>✓ Bundle conversions</p>
+          <p>✓ Price volatility warnings</p>
+        </div>
+        <Link href="/signup" className="px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700">Create Free Account</Link>
+      </div>
+    </div>
+  )
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,3 +1,0 @@
-export default function Custom404() {
-  return <div className="p-8 text-center">Page Not Found</div>;
-}

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,3 +1,0 @@
-export default function Custom500() {
-  return <div className="p-8 text-center">Server Error</div>;
-}


### PR DESCRIPTION
## Summary
- remove unused 404 and 500 pages causing build errors
- add Get Started page
- add placeholder tool pages for calculator, labor estimator, cash flow, change orders

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a8f6c4fec8323baa11f9667e68bba