### PR TITLE
Launch marketing upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@
 - Added confetti celebration on purchase success page.
 - Replaced "Authentication coming soon" message with real account instructions.
 - Tool pages now include product screenshots for better conversion.
+- Homepage hero redesigned for conversion with bullet benefits and animated carousel
+- Live user badge and newsletter signup forms for lead capture
+- Demo page now offers free sample via email signup
+- Success page promotes bundle upgrade with animated banner

--- a/README.md
+++ b/README.md
@@ -158,3 +158,4 @@ Legacy sprint docs can be archived by running `scripts/archive-preV1.sh`.
 - [Launch Checklist](docs/launch/launch-checklist.md)
 - [Developer Portal Guide](docs/DEVELOPER_PORTAL.md)
 \n### Maintenance\n- Minor cleanup of error handling routes.
+- Marketing refresh: new hero, tool carousel and email capture

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -2,6 +2,7 @@
 import { Play, Shield, Clock, DollarSign, Users } from 'lucide-react'
 import { useState } from 'react'
 import Link from 'next/link'
+import EmailSignupForm from '../../components/marketing/EmailSignupForm'
 
 export default function DemoPage() {
   const [activeDemo, setActiveDemo] = useState('estimation')
@@ -101,6 +102,9 @@ export default function DemoPage() {
               Start Your Free Trial →
             </Link>
           </div>
+        </div>
+        <div className="max-w-md mx-auto mt-12">
+          <EmailSignupForm />
         </div>
       </div>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,9 @@ import Link from 'next/link'
 import { Shield, ArrowRight, Play, CheckCircle } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { AnimatedGradient, Hero3D } from '../components/ui'
+import FeaturedToolsCarousel from '../components/marketing/FeaturedToolsCarousel'
+import EmailSignupForm from '../components/marketing/EmailSignupForm'
+import ActiveUsersBadge from '../components/marketing/ActiveUsersBadge'
 import { useLocale } from '../src/context/LocaleContext'
 
 export const dynamic = 'force-dynamic'
@@ -12,11 +15,14 @@ export default function HomePage() {
   return (
     <section className="relative overflow-hidden bg-slate-900 py-24">
       <AnimatedGradient />
+      <div className="absolute top-6 right-6">
+        <ActiveUsersBadge />
+      </div>
       <div className="container relative mx-auto px-4 max-w-6xl">
         <div className="max-w-3xl">
           <div className="inline-flex items-center space-x-2 bg-white/10 backdrop-blur-sm rounded-full px-4 py-2 mb-8">
             <Shield className="w-5 h-5 text-green-400" />
-            <span className="text-sm font-medium text-white">Protecting 12,847 roofing professionals daily</span>
+            <span className="text-sm font-medium text-white">Trusted by 2,800+ contractors</span>
           </div>
           <motion.h1
             initial={{ opacity: 0, y: 40 }}
@@ -24,15 +30,27 @@ export default function HomePage() {
             transition={{ type: 'spring', stiffness: 80 }}
             className="text-5xl md:text-6xl font-bold text-white mb-6 leading-tight"
           >
-            {messages.home.titleStart}
-            <span className="text-blue-400"> {messages.home.titleEmphasis}</span>
+            Protect every project.
+            <span className="text-blue-400"> Grow every margin.</span>
           </motion.h1>
-          <p className="text-xl text-slate-300 mb-8 leading-relaxed">
-            When you're estimating a $2M project or managing crews across three sites,
-            you need more than software. You need a system that catches mistakes before
-            they cost you.
-          </p>
+          <ul className="text-slate-300 mb-8 space-y-2">
+            <li className="flex items-start gap-2">
+              <CheckCircle className="w-5 h-5 text-green-400" />
+              Instant AI estimates
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckCircle className="w-5 h-5 text-green-400" />
+              Error-proof templates
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckCircle className="w-5 h-5 text-green-400" />
+              Mobile field tools
+            </li>
+          </ul>
           <Hero3D />
+          <div className="my-8">
+            <FeaturedToolsCarousel />
+          </div>
           <div className="flex flex-col sm:flex-row gap-4">
             <Link href="/get-started" className="inline-flex items-center justify-center px-8 py-4 bg-blue-600 text-white rounded-lg font-semibold text-lg hover:bg-blue-700 transition-colors">
               {messages.home.startTrial}
@@ -56,6 +74,9 @@ export default function HomePage() {
               <CheckCircle className="w-5 h-5 text-green-400" />
               <span className="text-slate-300">99.9% Uptime</span>
             </div>
+          </div>
+          <div className="mt-12 max-w-md">
+            <EmailSignupForm />
           </div>
         </div>
       </div>

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { useEffect } from 'react';
 import { useConfetti } from '../../hooks/use-confetti';
+import UpgradeBanner from '../../components/marketing/UpgradeBanner';
 
 export default function SuccessPage() {
   const triggerConfetti = useConfetti();
@@ -11,6 +12,7 @@ export default function SuccessPage() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <div className="max-w-md w-full space-y-8 p-8 bg-white rounded-lg shadow">
+        <UpgradeBanner />
         <div className="text-center">
           <div className="mx-auto h-12 w-12 text-green-500">
             <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/components/marketing/ActiveUsersBadge.tsx
+++ b/components/marketing/ActiveUsersBadge.tsx
@@ -1,0 +1,12 @@
+'use client'
+import { usePresence } from '../ui/PresenceProvider'
+
+export default function ActiveUsersBadge() {
+  const users = usePresence()
+  if (users.length === 0) return null
+  return (
+    <span className="bg-white/10 backdrop-blur-sm text-white text-xs px-3 py-1 rounded-full">
+      {users.length} live users
+    </span>
+  )
+}

--- a/components/marketing/EmailSignupForm.tsx
+++ b/components/marketing/EmailSignupForm.tsx
@@ -1,0 +1,42 @@
+'use client'
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import Button from '../ui/Button'
+import Lottie from 'lottie-react'
+import successAnim from '../../public/empty-box.json'
+
+export default function EmailSignupForm({className=""}:{className?:string}) {
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<'idle'|'success'|'error'|'loading'>('idle')
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setStatus('loading')
+    try {
+      const res = await fetch('/api/subscribe', {method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify({email})})
+      if (res.ok) setStatus('success')
+      else throw new Error('fail')
+    } catch {
+      setStatus('error')
+    }
+  }
+  return (
+    <form onSubmit={submit} className={`space-y-4 ${className}`}>\
+      {status==='success' ? (
+        <motion.div initial={{opacity:0}} animate={{opacity:1}} className="flex flex-col items-center text-center">
+          <Lottie animationData={successAnim} className="w-24 h-24" loop={false}/>
+          <p className="text-green-600 font-semibold">Check your inbox!</p>
+        </motion.div>
+      ) : (
+        <>
+          <input type="email" required value={email} onChange={e=>setEmail(e.target.value)} placeholder="you@example.com" className="w-full px-4 py-3 rounded-lg text-gray-900"/>
+          <Button type="submit" className="w-full" disabled={status==='loading'}>
+            {status==='loading' ? 'Submitting...' : 'Get Free Sample'}
+          </Button>
+          <p className="text-xs text-gray-500 text-center">We respect your privacy. Unsubscribe anytime.</p>
+          {status==='error' && <p className="text-red-600 text-sm text-center">Something went wrong.</p>}
+        </>
+      )}
+    </form>
+  )
+}

--- a/components/marketing/FeaturedToolsCarousel.tsx
+++ b/components/marketing/FeaturedToolsCarousel.tsx
@@ -1,0 +1,79 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import Image from 'next/image'
+import Button from '../ui/Button'
+
+interface Tool {
+  id: string
+  name: string
+  image: string
+  cta: string
+  href: string
+}
+
+const tools: Tool[] = [
+  {
+    id: 'estimator',
+    name: 'AI Estimator',
+    image: 'https://images.unsplash.com/photo-1581091215367-59ab8eebc106?auto=format&w=800',
+    cta: 'Try Demo',
+    href: '/estimator'
+  },
+  {
+    id: 'materials',
+    name: 'Material Calculator',
+    image: 'https://images.unsplash.com/photo-1590944451268-38cb8f7bfc4e?auto=format&w=800',
+    cta: 'View Tool',
+    href: '/marketplace'
+  },
+  {
+    id: 'templates',
+    name: 'Contract Templates',
+    image: 'https://images.unsplash.com/photo-1559027615-5db1c128aa84?auto=format&w=800',
+    cta: 'Buy Now',
+    href: '/marketplace'
+  }
+]
+
+export default function FeaturedToolsCarousel() {
+  const [index, setIndex] = useState(0)
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % tools.length)
+    }, 5000)
+    return () => clearInterval(id)
+  }, [])
+  return (
+    <div className="relative overflow-hidden">
+      <div className="flex justify-center mb-4 gap-2">
+        {tools.map((t, i) => (
+          <button
+            key={t.id}
+            onClick={() => setIndex(i)}
+            className={`w-2 h-2 rounded-full ${i === index ? 'bg-blue-600 w-3' : 'bg-gray-300'}`}
+          />
+        ))}
+      </div>
+      <div className="relative h-64 rounded-2xl overflow-hidden">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={index}
+            initial={{ opacity: 0, x: 50 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -50 }}
+            className="absolute inset-0"
+          >
+            <Image src={tools[index].image} alt={tools[index].name} fill className="object-cover" />
+            <div className="absolute inset-0 bg-slate-900/50 flex flex-col items-center justify-center text-center p-4">
+              <h3 className="text-2xl font-bold text-white mb-4 drop-shadow-lg">{tools[index].name}</h3>
+              <Button as="a" href={tools[index].href} className="px-6 py-3">
+                {tools[index].cta}
+              </Button>
+            </div>
+          </motion.div>
+        </AnimatePresence>
+      </div>
+    </div>
+  )
+}

--- a/components/marketing/UpgradeBanner.tsx
+++ b/components/marketing/UpgradeBanner.tsx
@@ -1,0 +1,18 @@
+'use client'
+import Button from '../ui/Button'
+import { motion } from 'framer-motion'
+
+export default function UpgradeBanner() {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="bg-blue-600 text-white p-4 rounded-lg mb-6 flex items-center justify-between"
+    >
+      <p className="font-semibold">Upgrade to Pro and get every tool at 25% off!</p>
+      <Button as="a" href="/marketplace" variant="secondary" className="bg-white text-blue-600 hover:bg-white/80">
+        View Bundles
+      </Button>
+    </motion.div>
+  )
+}


### PR DESCRIPTION
## Summary
- add marketing-focused carousel and signup components
- update homepage hero, lead capture and live user badge
- enhance demo page with email signup
- show upgrade banner after purchase
- document changes in README and CHANGELOG

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ae0374d448323980c52577aafa532