### PR TITLE
Enhance UI with glassmorphism

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import ErrorBoundary from '../components/ErrorBoundary';
 import CopilotWrapper from '../components/layout/CopilotWrapper';
 import dynamicImport from 'next/dynamic';
 const Starfield = dynamicImport(() => import('../components/Starfield'), { ssr: false });
+const MotionDiv = dynamicImport(() => import('framer-motion').then(m => m.motion.div), { ssr: false });
 import './lib/sentry';
 import { maintenanceMode, aiCopilotEnabled, arModeEnabled } from './lib/features';
 
@@ -47,7 +48,10 @@ export default function RootLayout({
         <LocaleProvider>
         <CurrencyProvider>
         <DocumentLang />
-        <div className="bg-bg min-h-screen text-text-primary font-inter">
+        <MotionDiv
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="bg-bg/60 backdrop-blur-lg glass rounded-2xl shadow-2xl min-h-screen text-text-primary font-inter">
           <AuthProvider>
           <RoleProvider>
             <ThemeProvider>
@@ -79,7 +83,7 @@ export default function RootLayout({
             </ThemeProvider>
           </RoleProvider>
           </AuthProvider>
-        </div>
+        </MotionDiv>
         </CurrencyProvider>
         </LocaleProvider>
       </body>

--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -182,7 +182,11 @@ export default function Marketplace() {
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Hero Section */}
-      <section className="bg-gradient-to-r from-blue-600 to-blue-800 text-white py-12">
+      <motion.section
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="bg-gradient-to-r from-blue-600 to-blue-800/80 text-white py-12 backdrop-blur-lg rounded-2xl shadow-2xl">
         <div className="max-w-7xl mx-auto px-4">
           <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
             <div>
@@ -202,7 +206,7 @@ export default function Marketplace() {
                 </div>
               </div>
             </div>
-            <div className="bg-white/10 backdrop-blur rounded-lg p-6 text-center">
+            <div className="bg-white/30 backdrop-blur-lg rounded-2xl shadow-2xl p-6 text-center">
               <p className="text-3xl font-bold">{products.length}</p>
               <p className="text-blue-100">Products Available</p>
             </div>
@@ -222,7 +226,7 @@ export default function Marketplace() {
             </div>
           </div>
         </div>
-      </section>
+        </motion.section>
 
       {/* Main Content */}
       <div className="max-w-7xl mx-auto px-4 py-8">
@@ -560,7 +564,11 @@ export default function Marketplace() {
       </div>
 
       {/* Newsletter CTA */}
-      <section className="bg-blue-600 py-12 mt-16">
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        className="bg-blue-600/80 backdrop-blur-lg py-12 mt-16 rounded-2xl shadow-2xl">
         <div className="max-w-4xl mx-auto px-4 text-center">
           <h2 className="text-3xl font-bold text-white mb-4">
             Get Exclusive Deals & New Product Updates
@@ -582,7 +590,7 @@ export default function Marketplace() {
             </button>
           </form>
         </div>
-      </section>
+      </motion.section>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,14 +13,18 @@ export const dynamic = 'force-dynamic'
 export default function HomePage() {
   const { messages } = useLocale();
   return (
-    <section className="relative overflow-hidden bg-slate-900 py-24">
+    <motion.section
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.6 }}
+      className="relative overflow-hidden bg-slate-900 py-24 backdrop-blur-lg bg-white/10 rounded-2xl shadow-2xl">
       <AnimatedGradient />
       <div className="absolute top-6 right-6">
         <ActiveUsersBadge />
       </div>
       <div className="container relative mx-auto px-4 max-w-6xl">
         <div className="max-w-3xl">
-          <div className="inline-flex items-center space-x-2 bg-white/10 backdrop-blur-sm rounded-full px-4 py-2 mb-8">
+          <div className="inline-flex items-center space-x-2 bg-white/30 backdrop-blur-lg rounded-full shadow-2xl px-4 py-2 mb-8">
             <Shield className="w-5 h-5 text-green-400" />
             <span className="text-sm font-medium text-white">Trusted by 2,800+ contractors</span>
           </div>
@@ -53,14 +57,14 @@ export default function HomePage() {
           <div className="flex flex-col sm:flex-row gap-4">
             <Link
               href="/get-started"
-              className="inline-flex items-center justify-center px-8 py-4 bg-blue-600 text-white rounded-lg font-semibold text-lg hover:bg-blue-700 transition-colors glow-btn animate-ripple"
+              className="inline-flex items-center justify-center px-8 py-4 bg-blue-600/80 backdrop-blur-lg text-white rounded-2xl shadow-2xl font-semibold text-lg hover:bg-blue-700 transition-colors glow-btn animate-ripple"
             >
               {messages.home.startTrial}
               <ArrowRight className="ml-2 w-5 h-5" />
             </Link>
             <Link
               href="/demo"
-              className="inline-flex items-center justify-center px-8 py-4 bg-white/10 backdrop-blur-sm text-white rounded-lg font-semibold text-lg hover:bg-white/20 transition-colors glow-btn animate-ripple"
+              className="inline-flex items-center justify-center px-8 py-4 bg-white/30 backdrop-blur-lg text-white rounded-2xl shadow-2xl font-semibold text-lg hover:bg-white/20 transition-colors glow-btn animate-ripple"
             >
               <Play className="mr-2 w-5 h-5" />
               {messages.home.watchDemo}
@@ -85,6 +89,6 @@ export default function HomePage() {
           </div>
         </div>
       </div>
-    </section>
+      </motion.section>
   )
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -51,7 +51,7 @@ export default function Navbar() {
         initial={{ y: -100, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ type: 'spring', stiffness: 70 }}
-        className="glass-navbar fixed top-0 w-full flex items-center justify-between px-8 py-4 z-50"
+        className="glass-navbar rounded-2xl shadow-2xl fixed top-0 w-full flex items-center justify-between px-8 py-4 z-50"
       >
         <div className="text-accent text-2xl font-bold">MyRoofGenius</div>
         <div className="hidden md:flex gap-6">
@@ -104,7 +104,7 @@ export default function Navbar() {
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
-            className="md:hidden bg-[rgba(35,35,35,0.9)] backdrop-blur-xl border-b border-[rgba(255,255,255,0.07)] fixed top-16 w-full z-40 overflow-hidden"
+            className="md:hidden bg-[rgba(35,35,35,0.9)] backdrop-blur-xl border-b border-[rgba(255,255,255,0.07)] rounded-b-2xl shadow-2xl fixed top-16 w-full z-40 overflow-hidden"
           >
             {links.map(({ href, label }) => (
               <a

--- a/components/marketing/EmailSignupForm.tsx
+++ b/components/marketing/EmailSignupForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState } from 'react'
 import { motion } from 'framer-motion'
+import clsx from 'clsx'
 import Button from '../ui/Button'
 import Lottie from 'lottie-react'
 import successAnim from '../../public/empty-box.json'
@@ -21,7 +22,12 @@ export default function EmailSignupForm({className=""}:{className?:string}) {
     }
   }
   return (
-    <form onSubmit={submit} className={`space-y-4 ${className}`}>\
+    <motion.form
+      onSubmit={submit}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      className={clsx('space-y-4 glass backdrop-blur-lg bg-white/30 rounded-2xl shadow-2xl p-6', className)}>
       {status==='success' ? (
         <motion.div initial={{opacity:0}} animate={{opacity:1}} className="flex flex-col items-center text-center">
           <Lottie animationData={successAnim} className="w-24 h-24" loop={false}/>
@@ -37,6 +43,6 @@ export default function EmailSignupForm({className=""}:{className?:string}) {
           {status==='error' && <p className="text-red-600 text-sm text-center">Something went wrong.</p>}
         </>
       )}
-    </form>
+    </motion.form>
   )
 }

--- a/components/marketing/FeaturedToolsCarousel.tsx
+++ b/components/marketing/FeaturedToolsCarousel.tsx
@@ -72,7 +72,7 @@ export default function FeaturedToolsCarousel() {
             }}
             onMouseLeave={() => setTilt({ x: 0, y: 0 })}
             style={{ rotateX: tilt.x, rotateY: tilt.y }}
-            className="absolute inset-0 glass-card"
+            className="absolute inset-0 glass-card backdrop-blur-lg bg-white/30 rounded-2xl shadow-2xl"
           >
             <Image src={tools[index].image} alt={tools[index].name} fill className="object-cover" />
             <div className="absolute inset-0 bg-slate-900/50 flex flex-col items-center justify-center text-center p-4">

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -23,7 +23,7 @@ export default function Card({ hover = true, glass = false, className, ...props 
   return (
     <motion.div
       {...motionProps}
-      className={clsx('rounded-lg p-6 min-h-[44px]', glass ? 'glass-card' : 'bg-bg-card', className)}
+      className={clsx('rounded-2xl p-6 min-h-[44px]', glass ? 'glass-card backdrop-blur-lg bg-white/30 shadow-2xl' : 'bg-bg-card', className)}
       {...props}
     />
   );

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -32,7 +32,7 @@ export default function Modal({ open, onClose, children }: ModalProps) {
               });
             }}
             style={{ rotateX: pos.y * -10, rotateY: pos.x * 10 }}
-            className="relative w-full max-w-lg p-6 glass rounded-xl text-white shadow-2xl"
+            className="relative w-full max-w-lg p-6 glass bg-white/30 backdrop-blur-lg rounded-2xl text-white shadow-2xl"
           >
             <button
               onClick={onClose}


### PR DESCRIPTION
## Summary
- add glass effect wrapper to root layout
- enhance navbar and mobile menu glass styling
- convert email signup form to glass motion form
- tweak card, modal and carousel for glass backdrop
- animate home hero and CTAs
- update marketplace hero and newsletter CTA with blur/animation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686afbc447b483238b13678b1d503368