### PR TITLE
Add motion and glass touches

### DIFF
--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -1,6 +1,8 @@
 'use client'
 import { Calculator, FileSpreadsheet, Layers, TrendingUp, DollarSign, Clock } from 'lucide-react'
 import Link from 'next/link'
+import { motion } from 'framer-motion'
+import Card from '@/components/ui/Card'
 
 export default function ToolsPage() {
   const tools = [
@@ -100,7 +102,10 @@ export default function ToolsPage() {
 
 function ToolCard({ name, description, features, link, icon, saveTime }) {
   return (
-    <div className="bg-white rounded-xl shadow-lg border border-slate-200 p-6 hover:shadow-xl transition-all">
+    <Card
+      glass
+      className="bg-white/30 backdrop-blur-lg shadow-xl border border-white/20 p-6"
+    >
       <div className="flex items-start justify-between mb-4">
         <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
           {icon}
@@ -113,16 +118,22 @@ function ToolCard({ name, description, features, link, icon, saveTime }) {
       <p className="text-slate-600 mb-4">{description}</p>
       <ul className="space-y-2 mb-6">
         {features.map((feature, i) => (
-          <li key={i} className="flex items-center text-sm text-slate-700">
+          <motion.li
+            key={i}
+            initial={{ opacity: 0, x: -10 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: i * 0.05 }}
+            className="flex items-center text-sm text-slate-700"
+          >
             <span className="text-green-500 mr-2">✓</span>
             {feature}
-          </li>
+          </motion.li>
         ))}
       </ul>
       <Link href={link} className="block text-center py-2 px-4 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-semibold">
         Open Tool →
       </Link>
-    </div>
+    </Card>
   )
 }
 

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,20 +1,30 @@
 'use client';
 import {useLocale} from '../src/context/LocaleContext';
+import { motion } from 'framer-motion';
 
 export default function LanguageSwitcher() {
-  const {locale, setLocale, messages} = useLocale();
+  const { locale, setLocale, messages } = useLocale();
   return (
-    <div className="flex items-center space-x-2 text-sm">
+    <motion.div
+      initial={{ opacity: 0, y: -5 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ type: 'spring', stiffness: 120 }}
+      className="flex items-center space-x-2 text-sm"
+    >
       <span>{messages.language}:</span>
-      {['en', 'es'].map(l => (
-        <button
+      {['en', 'es'].map((l) => (
+        <motion.button
           key={l}
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
           onClick={() => setLocale(l)}
-          className={`px-2 py-1 rounded ${locale === l ? 'bg-blue-600 text-white' : 'bg-gray-100'}`}
+          className={`px-2 py-1 rounded ${
+            locale === l ? 'bg-blue-600 text-white' : 'bg-gray-100'
+          }`}
         >
           {l.toUpperCase()}
-        </button>
+        </motion.button>
       ))}
-    </div>
+    </motion.div>
   );
 }

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState } from 'react'
+import { motion } from 'framer-motion'
 
 export default function SearchBar() {
   const [query, setQuery] = useState('')
@@ -23,24 +24,32 @@ export default function SearchBar() {
   }
 
   return (
-    <div className="relative">
-      <input
+    <motion.div
+      initial={{ opacity: 0, y: -10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ type: 'spring', stiffness: 100 }}
+      className="relative"
+    >
+      <motion.input
         type="text"
         value={query}
-        onChange={(e)=>setQuery(e.target.value)}
-        onKeyDown={(e)=>{ if(e.key==='Enter') search() }}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') search();
+        }}
         placeholder="Search..."
-        className="border px-2 py-1 rounded"
+        whileFocus={{ scale: 1.05 }}
+        className="border px-3 py-2 rounded-xl glass-card w-full"
       />
-      {results.length>0 && (
-        <ul className="absolute bg-white border mt-1 w-full z-10 max-h-64 overflow-y-auto">
-          {results.map(r=> (
-            <li key={r.id} className="px-2 py-1 hover:bg-gray-100 text-sm">
+      {results.length > 0 && (
+        <ul className="absolute mt-1 w-full z-10 max-h-64 overflow-y-auto glass-card backdrop-blur-lg border border-white/20 rounded-xl">
+          {results.map((r) => (
+            <li key={r.id} className="px-3 py-2 hover:bg-white/20 text-sm">
               {r.name}
             </li>
           ))}
         </ul>
       )}
-    </div>
-  )
+    </motion.div>
+  );
 }

--- a/components/marketplace/ContractorGrid.tsx
+++ b/components/marketplace/ContractorGrid.tsx
@@ -1,13 +1,25 @@
 'use client';
 import { Contractor } from '../../types/marketplace';
 import ContractorCard from './ContractorCard';
+import { motion } from 'framer-motion';
 
 export default function ContractorGrid({ contractors }: { contractors: Contractor[] }) {
   return (
-    <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <motion.div
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, amount: 0.2 }}
+      variants={{
+        hidden: { opacity: 0, y: 20 },
+        visible: { opacity: 1, y: 0, transition: { staggerChildren: 0.1 } }
+      }}
+      className="grid md:grid-cols-2 lg:grid-cols-3 gap-4"
+    >
       {contractors.map((c) => (
-        <ContractorCard key={c.id} contractor={c} />
+        <motion.div key={c.id} variants={{ hidden: { opacity: 0, y: 10 }, visible: { opacity: 1, y: 0 } }}>
+          <ContractorCard contractor={c} />
+        </motion.div>
       ))}
-    </div>
+    </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- animate search bar with motion and glass-style dropdown
- animate language switcher buttons
- add staggered motion to contractor cards
- convert Tools page cards to glass Card component with motion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b0e6f7fa48323839e9ddc5b720a81