### PR TITLE
Add glassmorphic footer and animations

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link'
 import { Shield, ArrowRight, Play, CheckCircle } from 'lucide-react'
 import { motion } from 'framer-motion'
+const MotionLink = motion(Link)
 import { AnimatedGradient, Hero3D, TypingText } from '../components/ui'
 import FeaturedToolsCarousel from '../components/marketing/FeaturedToolsCarousel'
 import EmailSignupForm from '../components/marketing/EmailSignupForm'
@@ -55,20 +56,22 @@ export default function HomePage() {
             <FeaturedToolsCarousel />
           </div>
           <div className="flex flex-col sm:flex-row gap-4">
-            <Link
+            <MotionLink
               href="/get-started"
-              className="inline-flex items-center justify-center px-8 py-4 bg-blue-600/80 backdrop-blur-lg text-white rounded-2xl shadow-2xl font-semibold text-lg hover:bg-blue-700 transition-colors glow-btn animate-ripple"
+              whileHover={{ scale: 1.05 }}
+              className="inline-flex items-center justify-center px-8 py-4 bg-blue-600/80 backdrop-blur-lg text-white rounded-2xl shadow-2xl font-semibold text-lg transition-colors glow-btn animate-ripple"
             >
               {messages.home.startTrial}
               <ArrowRight className="ml-2 w-5 h-5" />
-            </Link>
-            <Link
+            </MotionLink>
+            <MotionLink
               href="/demo"
-              className="inline-flex items-center justify-center px-8 py-4 bg-white/30 backdrop-blur-lg text-white rounded-2xl shadow-2xl font-semibold text-lg hover:bg-white/20 transition-colors glow-btn animate-ripple"
+              whileHover={{ scale: 1.05 }}
+              className="inline-flex items-center justify-center px-8 py-4 bg-white/30 backdrop-blur-lg text-white rounded-2xl shadow-2xl font-semibold text-lg transition-colors glow-btn animate-ripple"
             >
               <Play className="mr-2 w-5 h-5" />
               {messages.home.watchDemo}
-            </Link>
+            </MotionLink>
           </div>
           <div className="mt-12 flex flex-wrap gap-8">
             <div className="flex items-center space-x-3">

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -104,6 +104,9 @@ function ToolCard({ name, description, features, link, icon, saveTime }) {
   return (
     <Card
       glass
+      initial={{ opacity: 0, y: 40 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
       className="bg-white/30 backdrop-blur-lg shadow-xl border border-white/20 p-6"
     >
       <div className="flex items-start justify-between mb-4">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,28 @@
+'use client'
+import { motion } from 'framer-motion'
+import { Github, Twitter } from 'lucide-react'
+
+export default function Footer() {
+  const icons = [
+    { href: 'https://github.com/myroofgenius', Icon: Github },
+    { href: 'https://twitter.com/myroofgenius', Icon: Twitter },
+  ]
+  return (
+    <motion.footer
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="glass-navbar mt-12 rounded-t-2xl py-6 flex justify-center gap-6 backdrop-blur-md"
+    >
+      {icons.map(({ href, Icon }) => (
+        <motion.a
+          key={href}
+          href={href}
+          whileHover={{ scale: 1.2, rotate: 5 }}
+          className="text-white hover:text-accent glow-btn animate-ripple rounded-full p-2"
+        >
+          <Icon className="w-5 h-5" />
+        </motion.a>
+      ))}
+    </motion.footer>
+  )
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import type { User } from '@supabase/supabase-js';
 import { motion, AnimatePresence } from 'framer-motion';
+import AnimatedGradient from './ui/AnimatedGradient';
 import { Menu, X } from 'lucide-react';
 import { ThemeToggle, AccentColorPicker } from './ui';
 import LanguageSwitcher from './LanguageSwitcher';
@@ -51,14 +52,20 @@ export default function Navbar() {
         initial={{ y: -100, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ type: 'spring', stiffness: 70 }}
-        className="glass-navbar rounded-2xl shadow-2xl fixed top-0 w-full flex items-center justify-between px-8 py-4 z-50"
+        className="glass-navbar rounded-2xl shadow-2xl fixed top-0 w-full flex items-center justify-between px-8 py-4 z-50 overflow-hidden"
       >
+        <AnimatedGradient />
         <div className="text-accent text-2xl font-bold">MyRoofGenius</div>
         <div className="hidden md:flex gap-6">
           {links.map(({ href, label }) => (
-            <a key={href} href={href} className="hover:text-accent transition">
+            <motion.a
+              key={href}
+              href={href}
+              whileHover={{ scale: 1.1 }}
+              className="hover:text-accent transition"
+            >
               {label}
-            </a>
+            </motion.a>
           ))}
         </div>
         <div className="hidden md:flex items-center gap-4">
@@ -76,7 +83,7 @@ export default function Navbar() {
               <a href="/dashboard" className="text-sm font-medium hover:text-accent">
                 Dashboard
               </a>
-              <button onClick={handleSignOut} className="rounded-xl px-5 py-2 border border-accent text-accent hover:bg-accent hover:text-white transition">
+              <button onClick={handleSignOut} className="rounded-xl px-5 py-2 border border-accent text-accent hover:bg-accent hover:text-white transition glow-btn animate-ripple">
                 Sign Out
               </button>
             </>
@@ -85,12 +92,13 @@ export default function Navbar() {
               <a href="/login" className="text-sm font-medium hover:text-accent">
                 Sign In
               </a>
-              <a
+              <motion.a
                 href="/signup"
-                className="rounded-xl px-5 py-2 bg-accent text-white font-bold shadow-md hover:scale-105 transition glow-btn animate-ripple"
+                whileHover={{ scale: 1.05 }}
+                className="rounded-xl px-5 py-2 bg-accent text-white font-bold shadow-md transition glow-btn animate-ripple"
               >
                 Start Free Trial
-              </a>
+              </motion.a>
             </>
           )}
         </div>
@@ -106,15 +114,17 @@ export default function Navbar() {
             exit={{ height: 0, opacity: 0 }}
             className="md:hidden bg-[rgba(35,35,35,0.9)] backdrop-blur-xl border-b border-[rgba(255,255,255,0.07)] rounded-b-2xl shadow-2xl fixed top-16 w-full z-40 overflow-hidden"
           >
+            <AnimatedGradient />
             {links.map(({ href, label }) => (
-              <a
+              <motion.a
                 key={href}
                 href={href}
+                whileTap={{ scale: 0.95 }}
                 className="block px-8 py-4 border-b border-[rgba(255,255,255,0.07)] hover:text-accent"
                 onClick={() => setOpen(false)}
               >
                 {label}
-              </a>
+              </motion.a>
             ))}
             {user?.user_metadata?.role === 'admin' && (
               <a
@@ -153,13 +163,14 @@ export default function Navbar() {
                 >
                   Sign In
                 </a>
-                <a
+                <motion.a
                   href="/signup"
+                  whileTap={{ scale: 0.95 }}
                   className="block px-8 py-4 border-b border-[rgba(255,255,255,0.07)] hover:text-accent glow-btn animate-ripple"
                   onClick={() => setOpen(false)}
                 >
                   Start Free Trial
-                </a>
+                </motion.a>
               </>
             )}
             <div className="p-4 space-y-2">

--- a/components/layout/AnimatedLayout.tsx
+++ b/components/layout/AnimatedLayout.tsx
@@ -1,14 +1,16 @@
 "use client";
 import { motion } from "framer-motion";
 import type { ReactNode } from "react";
+import AnimatedGradient from "../ui/AnimatedGradient";
 
 export default function AnimatedLayout({ children }: { children: ReactNode }) {
   return (
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="bg-bg/60 backdrop-blur-lg glass rounded-2xl shadow-2xl min-h-screen text-text-primary font-inter"
+      className="bg-bg/60 backdrop-blur-lg glass rounded-2xl shadow-2xl min-h-screen text-text-primary font-inter relative overflow-hidden"
     >
+      <AnimatedGradient />
       {children}
     </motion.div>
   );

--- a/components/layout/ClientLayout.tsx
+++ b/components/layout/ClientLayout.tsx
@@ -10,6 +10,7 @@ import AnnouncementBanner from '../AnnouncementBanner';
 import ErrorBoundary from '../ErrorBoundary';
 import CopilotWrapper from './CopilotWrapper';
 import AnimatedLayout from './AnimatedLayout';
+import Footer from '../Footer';
 import { aiCopilotEnabled, arModeEnabled } from '../../app/lib/features';
 
 export default function ClientLayout({ children }: { children: ReactNode }) {
@@ -30,6 +31,7 @@ export default function ClientLayout({ children }: { children: ReactNode }) {
                         <RoleSwitcher />
                         <ErrorBoundary>{children}</ErrorBoundary>
                         {aiCopilotEnabled && <CopilotWrapper />}
+                        <Footer />
                       </ARModeProvider>
                     ) : (
                       <>
@@ -38,6 +40,7 @@ export default function ClientLayout({ children }: { children: ReactNode }) {
                         <RoleSwitcher />
                         <ErrorBoundary>{children}</ErrorBoundary>
                         {aiCopilotEnabled && <CopilotWrapper />}
+                        <Footer />
                       </>
                     )}
                   </PresenceProvider>

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -17,6 +17,7 @@ export default function Card({ hover = true, glass = false, className, ...props 
           boxShadow: '0 4px 20px rgba(0,0,0,0.25)',
           transition: { type: 'spring' as const, stiffness: 200, damping: 15 },
         },
+        whileTap: { scale: 0.97 },
         style: { perspective: 1000 },
       }
     : {};


### PR DESCRIPTION
## Summary
- create animated glass `Footer` component
- overlay gradient background in `AnimatedLayout` and `Navbar`
- animate nav links and signup buttons
- add page CTA motion effects
- animate tool cards with scroll-in effects
- add tap animation to `Card`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b1b437bb88323a5288a630f898b4a