### PR TITLE
Fix build with Document and error pages

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,0 +1,14 @@
+import { NextPageContext } from 'next';
+
+function Error({ statusCode }: { statusCode: number | undefined }) {
+  return (
+    <p>{statusCode ? `An error ${statusCode} occurred on server` : 'An error occurred on client'}</p>
+  );
+}
+
+Error.getInitialProps = ({ res, err }: NextPageContext) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  return { statusCode };
+};
+
+export default Error;


### PR DESCRIPTION
## Summary
- add custom `_document` and `_error` pages to satisfy Next.js build checks
- ensure build completes successfully

## Testing
- `npm run build`
- `npm test`
- `npx playwright test` *(fails: ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_686b330182fc8323ab82a3623590b2af