### PR TITLE
Add testimonials and tool demos

### DIFF
--- a/app/blog/[slug]/head.tsx
+++ b/app/blog/[slug]/head.tsx
@@ -1,0 +1,12 @@
+export default function Head() {
+  return (
+    <>
+      <title>Article - MyRoofGenius</title>
+      <meta name="description" content="Detailed roofing insights from the MyRoofGenius team." />
+      <meta property="og:title" content="Article - MyRoofGenius" />
+      <meta property="og:description" content="Detailed roofing insights from the MyRoofGenius team." />
+      <meta name="twitter:title" content="Article - MyRoofGenius" />
+      <meta name="twitter:description" content="Detailed roofing insights from the MyRoofGenius team." />
+    </>
+  )
+}

--- a/app/blog/head.tsx
+++ b/app/blog/head.tsx
@@ -1,0 +1,12 @@
+export default function Head() {
+  return (
+    <>
+      <title>Roofing Insights Blog - MyRoofGenius</title>
+      <meta name="description" content="Expert guidance on estimation, project management and business growth." />
+      <meta property="og:title" content="Roofing Insights Blog - MyRoofGenius" />
+      <meta property="og:description" content="Expert guidance on estimation, project management and business growth." />
+      <meta name="twitter:title" content="Roofing Insights Blog - MyRoofGenius" />
+      <meta name="twitter:description" content="Expert guidance on estimation, project management and business growth." />
+    </>
+  )
+}

--- a/app/fieldapps/head.tsx
+++ b/app/fieldapps/head.tsx
@@ -3,6 +3,10 @@ export default function Head() {
     <>
       <title>Field Apps - MyRoofGenius</title>
       <meta name="description" content="Preview mobile tools for inspections, proposals, and punchlists." />
+      <meta property="og:title" content="Field Apps - MyRoofGenius" />
+      <meta property="og:description" content="Preview mobile tools for inspections, proposals, and punchlists." />
+      <meta name="twitter:title" content="Field Apps - MyRoofGenius" />
+      <meta name="twitter:description" content="Preview mobile tools for inspections, proposals, and punchlists." />
     </>
   );
 }

--- a/app/fieldapps/page.tsx
+++ b/app/fieldapps/page.tsx
@@ -10,17 +10,17 @@ export default function FieldApps() {
     {
       title: 'Smart Field Inspection',
       description: 'Capture photos, annotate issues, and auto-log GPS/metadata.',
-      url: 'https://claude.ai/inspection'
+      url: null
     },
     {
       title: 'On-Site Proposal Generator',
       description: 'Instantly draft proposals and estimates from your phone.',
-      url: 'https://claude.ai/proposal'
+      url: null
     },
     {
       title: 'Real-Time Punchlist Dashboard',
       description: 'Track project tasks collaboratively with AI suggestions.',
-      url: 'https://claude.ai/punchlist'
+      url: null
     }
   ];
   return (
@@ -36,7 +36,11 @@ export default function FieldApps() {
               <h3 className="text-xl font-semibold mb-2">{app.title}</h3>
               <p className="text-text-secondary mb-4">{app.description}</p>
             </div>
-            <Button onClick={() => window.open(app.url, '_blank')}>Try Demo</Button>
+            {app.url ? (
+              <Button onClick={() => window.open(app.url!, '_blank')}>Try Demo</Button>
+            ) : (
+              <Button disabled className="bg-gray-300 text-gray-600 cursor-not-allowed">Coming Soon</Button>
+            )}
           </Card>
         ))}
       </div>

--- a/app/head.tsx
+++ b/app/head.tsx
@@ -3,6 +3,10 @@ export default function Head() {
     <>
       <title>MyRoofGenius - Roofing Intelligence Tools</title>
       <meta name="description" content="Protect margins and streamline projects with AI-powered calculators and field apps." />
+      <meta property="og:title" content="MyRoofGenius - Roofing Intelligence Tools" />
+      <meta property="og:description" content="Protect margins and streamline projects with AI-powered calculators and field apps." />
+      <meta name="twitter:title" content="MyRoofGenius - Roofing Intelligence Tools" />
+      <meta name="twitter:description" content="Protect margins and streamline projects with AI-powered calculators and field apps." />
     </>
   );
 }

--- a/app/login/head.tsx
+++ b/app/login/head.tsx
@@ -1,0 +1,12 @@
+export default function Head() {
+  return (
+    <>
+      <title>Login - MyRoofGenius</title>
+      <meta name="description" content="Sign in to access AI-powered roofing tools." />
+      <meta property="og:title" content="Login - MyRoofGenius" />
+      <meta property="og:description" content="Sign in to access AI-powered roofing tools." />
+      <meta name="twitter:title" content="Login - MyRoofGenius" />
+      <meta name="twitter:description" content="Sign in to access AI-powered roofing tools." />
+    </>
+  )
+}

--- a/app/marketplace/head.tsx
+++ b/app/marketplace/head.tsx
@@ -3,6 +3,10 @@ export default function Head() {
     <>
       <title>Marketplace - MyRoofGenius</title>
       <meta name="description" content="Browse professional roofing tools and templates ready for instant download." />
+      <meta property="og:title" content="Marketplace - MyRoofGenius" />
+      <meta property="og:description" content="Browse professional roofing tools and templates ready for instant download." />
+      <meta name="twitter:title" content="Marketplace - MyRoofGenius" />
+      <meta name="twitter:description" content="Browse professional roofing tools and templates ready for instant download." />
     </>
   );
 }

--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -9,6 +9,7 @@ import { Search, Filter, Star, ShoppingCart, Eye } from 'lucide-react';
 import ProductCarousel from '../../components/marketplace/ProductCarousel';
 import ContractorGrid from '../../components/marketplace/ContractorGrid';
 import { Product as RecommendedProduct, Contractor } from '../../types/marketplace';
+import Testimonials from '../../components/marketing/Testimonials';
 
 const categories = [
   { id: 'all', name: 'All Products', icon: '🏠' },
@@ -564,6 +565,8 @@ export default function Marketplace() {
           </main>
         </div>
       </div>
+
+      <Testimonials className="bg-gray-50" />
 
       {/* Newsletter CTA */}
       <motion.section

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ const MotionLink = motion(Link)
 import { AnimatedGradient, Hero3D, TypingText } from '../components/ui'
 import FeaturedToolsCarousel from '../components/marketing/FeaturedToolsCarousel'
 import EmailSignupForm from '../components/marketing/EmailSignupForm'
+import Testimonials from '../components/marketing/Testimonials'
 import ActiveUsersBadge from '../components/marketing/ActiveUsersBadge'
 import { useLocale } from '../src/context/LocaleContext'
 
@@ -14,6 +15,7 @@ export const dynamic = 'force-dynamic'
 export default function HomePage() {
   const { messages } = useLocale();
   return (
+    <>
     <motion.section
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
@@ -87,11 +89,13 @@ export default function HomePage() {
               <span className="text-slate-300">99.9% Uptime</span>
             </div>
           </div>
-          <div className="mt-12 max-w-md">
-            <EmailSignupForm />
-          </div>
-        </div>
+      <div className="mt-12 max-w-md">
+        <EmailSignupForm />
       </div>
-      </motion.section>
+    </div>
+  </div>
+  </motion.section>
+  <Testimonials className="bg-gray-50" />
+  </>
   )
 }

--- a/app/tools/cash-flow/head.tsx
+++ b/app/tools/cash-flow/head.tsx
@@ -3,6 +3,10 @@ export default function Head() {
     <>
       <title>Cash Flow Forecaster Demo - MyRoofGenius</title>
       <meta name="description" content="Preview cash forecasting features that keep projects funded." />
+      <meta property="og:title" content="Cash Flow Forecaster Demo - MyRoofGenius" />
+      <meta property="og:description" content="Preview cash forecasting features that keep projects funded." />
+      <meta name="twitter:title" content="Cash Flow Forecaster Demo - MyRoofGenius" />
+      <meta name="twitter:description" content="Preview cash forecasting features that keep projects funded." />
     </>
   );
 }

--- a/app/tools/cash-flow/page.tsx
+++ b/app/tools/cash-flow/page.tsx
@@ -1,8 +1,11 @@
 'use client'
 import Link from 'next/link'
 import Image from 'next/image'
+import { useState } from 'react'
+import ToolDemoModal from '../../../components/marketing/ToolDemoModal'
 
 export default function CashFlow() {
+  const [showDemo, setShowDemo] = useState(false)
   return (
     <div className="min-h-screen bg-gray-50 p-8 flex items-center justify-center">
       <div className="max-w-2xl bg-white rounded-xl shadow p-8 text-center">
@@ -21,9 +24,10 @@ export default function CashFlow() {
           <p>✓ Multi-project view</p>
         </div>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Link href="/demo" className="px-6 py-3 bg-gray-200 rounded-lg font-semibold hover:bg-gray-300 text-gray-800">Try Demo</Link>
+          <button onClick={() => setShowDemo(true)} className="px-6 py-3 bg-gray-200 rounded-lg font-semibold hover:bg-gray-300 text-gray-800">Try Demo</button>
           <Link href="/signup" className="px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700">Create Free Account</Link>
         </div>
+        <ToolDemoModal open={showDemo} onClose={() => setShowDemo(false)} title="Cash Flow Forecaster" />
       </div>
     </div>
   )

--- a/app/tools/change-orders/head.tsx
+++ b/app/tools/change-orders/head.tsx
@@ -3,6 +3,10 @@ export default function Head() {
     <>
       <title>Change Order Calculator Demo - MyRoofGenius</title>
       <meta name="description" content="Preview how to price project changes fairly while protecting margins." />
+      <meta property="og:title" content="Change Order Calculator Demo - MyRoofGenius" />
+      <meta property="og:description" content="Preview how to price project changes fairly while protecting margins." />
+      <meta name="twitter:title" content="Change Order Calculator Demo - MyRoofGenius" />
+      <meta name="twitter:description" content="Preview how to price project changes fairly while protecting margins." />
     </>
   );
 }

--- a/app/tools/change-orders/page.tsx
+++ b/app/tools/change-orders/page.tsx
@@ -1,8 +1,11 @@
 'use client'
 import Link from 'next/link'
 import Image from 'next/image'
+import { useState } from 'react'
+import ToolDemoModal from '../../../components/marketing/ToolDemoModal'
 
 export default function ChangeOrders() {
+  const [showDemo, setShowDemo] = useState(false)
   return (
     <div className="min-h-screen bg-gray-50 p-8 flex items-center justify-center">
       <div className="max-w-2xl bg-white rounded-xl shadow p-8 text-center">
@@ -21,9 +24,10 @@ export default function ChangeOrders() {
           <p>✓ Client-ready reports</p>
         </div>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Link href="/demo" className="px-6 py-3 bg-gray-200 rounded-lg font-semibold hover:bg-gray-300 text-gray-800">Try Demo</Link>
+          <button onClick={() => setShowDemo(true)} className="px-6 py-3 bg-gray-200 rounded-lg font-semibold hover:bg-gray-300 text-gray-800">Try Demo</button>
           <Link href="/signup" className="px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700">Create Free Account</Link>
         </div>
+        <ToolDemoModal open={showDemo} onClose={() => setShowDemo(false)} title="Change Order Calculator" />
       </div>
     </div>
   )

--- a/app/tools/head.tsx
+++ b/app/tools/head.tsx
@@ -3,6 +3,10 @@ export default function Head() {
     <>
       <title>Tools - MyRoofGenius</title>
       <meta name="description" content="Preview our suite of professional roofing calculators and business tools." />
+      <meta property="og:title" content="Tools - MyRoofGenius" />
+      <meta property="og:description" content="Preview our suite of professional roofing calculators and business tools." />
+      <meta name="twitter:title" content="Tools - MyRoofGenius" />
+      <meta name="twitter:description" content="Preview our suite of professional roofing calculators and business tools." />
     </>
   );
 }

--- a/app/tools/labor-estimator/head.tsx
+++ b/app/tools/labor-estimator/head.tsx
@@ -3,6 +3,10 @@ export default function Head() {
     <>
       <title>Labor Estimator Demo - MyRoofGenius</title>
       <meta name="description" content="Explore how the labor estimator forecasts crew needs and productivity." />
+      <meta property="og:title" content="Labor Estimator Demo - MyRoofGenius" />
+      <meta property="og:description" content="Explore how the labor estimator forecasts crew needs and productivity." />
+      <meta name="twitter:title" content="Labor Estimator Demo - MyRoofGenius" />
+      <meta name="twitter:description" content="Explore how the labor estimator forecasts crew needs and productivity." />
     </>
   );
 }

--- a/app/tools/labor-estimator/page.tsx
+++ b/app/tools/labor-estimator/page.tsx
@@ -1,8 +1,11 @@
 'use client'
 import Link from 'next/link'
 import Image from 'next/image'
+import { useState } from 'react'
+import ToolDemoModal from '../../../components/marketing/ToolDemoModal'
 
 export default function LaborEstimator() {
+  const [showDemo, setShowDemo] = useState(false)
   return (
     <div className="min-h-screen bg-gray-50 p-8 flex items-center justify-center">
       <div className="max-w-2xl bg-white rounded-xl shadow p-8 text-center">
@@ -21,9 +24,10 @@ export default function LaborEstimator() {
           <p>✓ Overtime calculations</p>
         </div>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Link href="/demo" className="px-6 py-3 bg-gray-200 rounded-lg font-semibold hover:bg-gray-300 text-gray-800">Try Demo</Link>
+          <button onClick={() => setShowDemo(true)} className="px-6 py-3 bg-gray-200 rounded-lg font-semibold hover:bg-gray-300 text-gray-800">Try Demo</button>
           <Link href="/signup" className="px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700">Create Free Account</Link>
         </div>
+        <ToolDemoModal open={showDemo} onClose={() => setShowDemo(false)} title="Labor Hour Estimator" />
       </div>
     </div>
   )

--- a/app/tools/material-calculator/head.tsx
+++ b/app/tools/material-calculator/head.tsx
@@ -3,6 +3,10 @@ export default function Head() {
     <>
       <title>Material Calculator Demo - MyRoofGenius</title>
       <meta name="description" content="Preview how our calculator instantly computes roofing materials." />
+      <meta property="og:title" content="Material Calculator Demo - MyRoofGenius" />
+      <meta property="og:description" content="Preview how our calculator instantly computes roofing materials." />
+      <meta name="twitter:title" content="Material Calculator Demo - MyRoofGenius" />
+      <meta name="twitter:description" content="Preview how our calculator instantly computes roofing materials." />
     </>
   );
 }

--- a/app/tools/material-calculator/page.tsx
+++ b/app/tools/material-calculator/page.tsx
@@ -1,8 +1,11 @@
 'use client'
 import Link from 'next/link'
 import Image from 'next/image'
+import { useState } from 'react'
+import ToolDemoModal from '../../../components/marketing/ToolDemoModal'
 
 export default function MaterialCalculator() {
+  const [showDemo, setShowDemo] = useState(false)
   return (
     <div className="min-h-screen bg-gray-50 p-8 flex items-center justify-center">
       <div className="max-w-2xl bg-white rounded-xl shadow p-8 text-center">
@@ -21,9 +24,10 @@ export default function MaterialCalculator() {
           <p>✓ Price volatility warnings</p>
         </div>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Link href="/demo" className="px-6 py-3 bg-gray-200 rounded-lg font-semibold hover:bg-gray-300 text-gray-800">Try Demo</Link>
+          <button onClick={() => setShowDemo(true)} className="px-6 py-3 bg-gray-200 rounded-lg font-semibold hover:bg-gray-300 text-gray-800">Try Demo</button>
           <Link href="/signup" className="px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700">Create Free Account</Link>
         </div>
+        <ToolDemoModal open={showDemo} onClose={() => setShowDemo(false)} title="Material Calculator" />
       </div>
     </div>
   )

--- a/components/marketing/Testimonials.tsx
+++ b/components/marketing/Testimonials.tsx
@@ -1,0 +1,46 @@
+'use client'
+import clsx from 'clsx'
+
+interface Testimonial {
+  quote: string
+  name: string
+  role: string
+}
+
+const testimonials: Testimonial[] = [
+  {
+    quote:
+      'MyRoofGenius cut our estimation time in half while improving accuracy.',
+    name: 'Sarah Chen',
+    role: 'Senior Estimator, ABC Roofing',
+  },
+  {
+    quote:
+      "The AI insights help us identify issues before they become problems. We've reduced callbacks by 40%.",
+    name: 'Michael Rodriguez',
+    role: 'Operations Manager, Premier Roofing Co.',
+  },
+  {
+    quote:
+      'Finally, a platform that understands the complexity of commercial roofing. The ROI was immediate.',
+    name: 'Jennifer Park',
+    role: 'Facility Director, Corporate Properties Inc.',
+  },
+]
+
+export default function Testimonials({ className = '' }: { className?: string }) {
+  return (
+    <section className={clsx('py-12', className)}>
+      <h2 className="text-3xl font-bold text-center mb-8">What Contractors Say</h2>
+      <div className="grid md:grid-cols-3 gap-6 max-w-6xl mx-auto px-4">
+        {testimonials.map((t, i) => (
+          <div key={i} className="bg-white rounded-xl shadow p-6">
+            <p className="mb-4">&ldquo;{t.quote}&rdquo;</p>
+            <p className="font-semibold">{t.name}</p>
+            <p className="text-sm text-gray-500">{t.role}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/marketing/ToolDemoModal.tsx
+++ b/components/marketing/ToolDemoModal.tsx
@@ -1,0 +1,45 @@
+'use client'
+import { useState } from 'react'
+import Modal from '../ui/Modal'
+
+export default function ToolDemoModal({ open, onClose, title }: { open: boolean; onClose: () => void; title: string }) {
+  const [value, setValue] = useState('')
+  const [result, setResult] = useState<number | null>(null)
+
+  const run = () => {
+    const num = parseFloat(value)
+    if (!isNaN(num)) {
+      setResult(Number((num * 1.1).toFixed(2)))
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <h2 className="text-xl font-bold mb-4">{title} Demo</h2>
+      {result === null ? (
+        <div className="space-y-4">
+          <input
+            type="number"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="Enter a sample value"
+            className="w-full px-3 py-2 rounded text-gray-900"
+          />
+          <button onClick={run} className="px-4 py-2 bg-blue-600 text-white rounded">
+            See Result
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-4 text-center">
+          <p className="text-lg">Estimated result: <strong>{result}</strong></p>
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            Create Free Account
+          </button>
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,7 +3,14 @@ import { Html, Head, Main, NextScript } from 'next/document';
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        {/* Crisp live chat widget */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.$crisp=[];window.CRISP_WEBSITE_ID="dc1db799-7b57-4a43-900a-70154904e6b2";(function(){var d=document,s=d.createElement('script');s.src='https://client.crisp.chat/l.js';s.async=1;d.getElementsByTagName('head')[0].appendChild(s);})();`
+          }}
+        />
+      </Head>
       <body>
         <Main />
         <NextScript />

--- a/tests/components/Card.test.tsx
+++ b/tests/components/Card.test.tsx
@@ -1,3 +1,4 @@
+/// <reference types="@testing-library/jest-dom" />
 import { render } from '@testing-library/react';
 import Card from '../../components/ui/Card';
 


### PR DESCRIPTION
## Summary
- add Testimonials component and display on homepage & marketplace
- add ToolDemoModal and demo buttons for major tools
- integrate live chat via Crisp script
- mark field apps as Coming Soon and add meta tags
- provide SEO head tags for key pages

## Testing
- `npm run type-check`
- `npm test`
- `npm run lint`
- `npx vercel --version` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_686b3f842ce883239269c76a8df48286