### PR TITLE
Implement crossfade headline to reduce CLS

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -94,4 +94,24 @@
     left: 100%;
   }
 }
+
+.hero-headline {
+  min-height: 3.5rem;
+  position: relative;
+  overflow: hidden;
+}
+.hero-headline span {
+  position: absolute;
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+}
+.hero-headline span.active {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-headline span {
+    transition: none;
+  }
+}
 @import "./styles/futuristic.css";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { Shield, ArrowRight, Play, CheckCircle } from 'lucide-react'
 import { motion } from 'framer-motion'
 const MotionLink = motion(Link)
-import { AnimatedGradient, Hero3D, TypingText } from '../components/ui'
+import { AnimatedGradient, Hero3D, HeroHeadline } from '../components/ui'
 import FeaturedToolsCarousel from '../components/marketing/FeaturedToolsCarousel'
 import EmailSignupForm from '../components/marketing/EmailSignupForm'
 import Testimonials from '../components/marketing/Testimonials'
@@ -37,7 +37,7 @@ export default function HomePage() {
             transition={{ type: 'spring', stiffness: 80 }}
             className="text-5xl md:text-6xl font-bold text-white mb-6 leading-tight"
           >
-            <TypingText texts={["Protect every project.", "Grow every margin."]} className="text-blue-400" />
+            <HeroHeadline texts={["Protect every project.", "Grow every margin."]} className="text-blue-400" />
           </motion.h1>
           <ul className="text-slate-300 mb-8 space-y-2">
             <li className="flex items-start gap-2">

--- a/components/ui/HeroHeadline.tsx
+++ b/components/ui/HeroHeadline.tsx
@@ -1,0 +1,38 @@
+'use client'
+import { useState, useEffect } from 'react'
+import clsx from 'clsx'
+
+interface HeroHeadlineProps {
+  texts: string[]
+  interval?: number
+  className?: string
+}
+
+export default function HeroHeadline({ texts, interval = 3000, className }: HeroHeadlineProps) {
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (prefersReduced) return
+    const timer = setInterval(() => {
+      setIndex((i) => (i + 1) % texts.length)
+    }, interval)
+    return () => clearInterval(timer)
+  }, [texts, interval])
+
+  return (
+    <span className={clsx('hero-headline block min-h-[3.5rem] relative', className)}>
+      {texts.map((text, i) => (
+        <span
+          key={i}
+          className={clsx(
+            'absolute inset-0 flex items-center opacity-0 transition-opacity',
+            i === index && 'active'
+          )}
+        >
+          {text}
+        </span>
+      ))}
+    </span>
+  )
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -15,3 +15,4 @@ export { default as Modal } from './Modal';
 export { PresenceProvider } from './PresenceProvider';
 export { default as PresenceAvatars } from './PresenceAvatars';
 export { default as TypingText } from './TypingText';
+export { default as HeroHeadline } from './HeroHeadline';


### PR DESCRIPTION
## Summary
- add `HeroHeadline` component for crossfade rotation
- include crossfade animation CSS and prefers-reduced-motion support
- update homepage to use `HeroHeadline` instead of TypingText

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_686d358bf8408323a761504e090f94cb