### PR TITLE
feat: brand palette refresh

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -10,6 +10,10 @@
 
   :root {
     --accent: 94 92 230;
+    --clr-primary-900: 13 27 42;
+    --clr-secondary-700: 63 28 112;
+    --clr-accent-emerald: 0 196 107;
+    --clr-accent-pink: 255 126 179;
     /* Protection Status Colors */
     --color-protected: 34 197 94;
     --color-warning: 251 146 60;
@@ -24,6 +28,15 @@
     --shadow-protected: 0 0 0 3px rgba(34, 197, 94, 0.1);
     --shadow-warning: 0 0 0 3px rgba(251, 146, 60, 0.1);
     --shadow-danger: 0 0 0 3px rgba(239, 68, 68, 0.1);
+  }
+
+  @supports not (color: oklch(0 0 0)) {
+    :root {
+      --clr-primary-900: 13 27 42;
+      --clr-secondary-700: 63 28 112;
+      --clr-accent-emerald: 0 196 107;
+      --clr-accent-pink: 255 126 179;
+    }
   }
 
   @media (prefers-contrast: high) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
 }) {
   if (maintenanceMode) {
     return (
-      <html lang="en" className="dark">
+      <html lang="en">
         <body className={inter.className}>
           <div className="min-h-screen flex items-center justify-center">
             <p>Site is under maintenance. Please check back soon.</p>
@@ -35,7 +35,7 @@ export default function RootLayout({
     );
   }
   return (
-    <html lang="en" className="dark">
+    <html lang="en">
       <body className={inter.className}>
         <Starfield />
         <ClientLayout>{children}</ClientLayout>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,10 +3,18 @@ import Link from 'next/link'
 import { Shield, ArrowRight, Play, CheckCircle } from 'lucide-react'
 import { motion } from 'framer-motion'
 const MotionLink = motion(Link)
-import { AnimatedGradient, Hero3D, HeroHeadline } from '../components/ui'
-import FeaturedToolsCarousel from '../components/marketing/FeaturedToolsCarousel'
+import { AnimatedGradient, Hero3D, HeroHeadline, Skeleton } from '../components/ui'
+import { Suspense } from 'react'
+import dynamicImport from 'next/dynamic'
 import EmailSignupForm from '../components/marketing/EmailSignupForm'
-import Testimonials from '../components/marketing/Testimonials'
+const FeaturedToolsCarousel = dynamicImport(
+  () => import('../components/marketing/FeaturedToolsCarousel'),
+  { ssr: false, loading: () => <div>Loading...</div> }
+)
+const Testimonials = dynamicImport(
+  () => import('../components/marketing/Testimonials'),
+  { ssr: false, loading: () => <div>Loading...</div> }
+)
 import ActiveUsersBadge from '../components/marketing/ActiveUsersBadge'
 import { useLocale } from '../src/context/LocaleContext'
 
@@ -20,7 +28,7 @@ export default function HomePage() {
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
       transition={{ duration: 0.6 }}
-      className="relative overflow-hidden bg-slate-900 py-24 backdrop-blur-lg bg-white/10 rounded-2xl shadow-2xl">
+      className="relative overflow-hidden bg-brand-gradient dark:bg-brand-gradient-alt py-24 backdrop-blur-lg rounded-2xl shadow-2xl">
       <AnimatedGradient />
       <div className="absolute top-6 right-6">
         <ActiveUsersBadge />
@@ -28,7 +36,7 @@ export default function HomePage() {
       <div className="container relative mx-auto px-4 max-w-6xl">
         <div className="max-w-3xl">
           <div className="inline-flex items-center space-x-2 bg-white/30 backdrop-blur-lg rounded-full shadow-2xl px-4 py-2 mb-8">
-            <Shield className="w-5 h-5 text-green-400" />
+            <Shield className="w-5 h-5 text-accent-emerald" />
             <span className="text-sm font-medium text-white">Trusted by 2,800+ contractors</span>
           </div>
           <motion.h1
@@ -37,31 +45,33 @@ export default function HomePage() {
             transition={{ type: 'spring', stiffness: 80 }}
             className="text-5xl md:text-6xl font-bold text-white mb-6 leading-tight"
           >
-            <HeroHeadline texts={["Protect every project.", "Grow every margin."]} className="text-blue-400" />
+            <HeroHeadline texts={["Protect every project.", "Grow every margin."]} className="text-accent-pink" />
           </motion.h1>
           <ul className="text-slate-300 mb-8 space-y-2">
             <li className="flex items-start gap-2">
-              <CheckCircle className="w-5 h-5 text-green-400" />
+              <CheckCircle className="w-5 h-5 text-accent-emerald" />
               Instant AI estimates
             </li>
             <li className="flex items-start gap-2">
-              <CheckCircle className="w-5 h-5 text-green-400" />
+              <CheckCircle className="w-5 h-5 text-accent-emerald" />
               Error-proof templates
             </li>
             <li className="flex items-start gap-2">
-              <CheckCircle className="w-5 h-5 text-green-400" />
+              <CheckCircle className="w-5 h-5 text-accent-emerald" />
               Mobile field tools
             </li>
           </ul>
           <Hero3D />
           <div className="my-8">
-            <FeaturedToolsCarousel />
+            <Suspense fallback={<Skeleton />}>
+              <FeaturedToolsCarousel />
+            </Suspense>
           </div>
           <div className="flex flex-col sm:flex-row gap-4">
             <MotionLink
               href="/get-started"
               whileHover={{ scale: 1.05 }}
-              className="inline-flex items-center justify-center px-8 py-4 bg-blue-600/80 backdrop-blur-lg text-white rounded-2xl shadow-2xl font-semibold text-lg transition-colors glow-btn animate-ripple"
+              className="inline-flex items-center justify-center px-8 py-4 bg-accent-emerald hover:bg-accent-emerald/80 text-white rounded-2xl shadow-2xl font-semibold text-lg transition-colors glow-btn animate-ripple"
             >
               {messages.home.startTrial}
               <ArrowRight className="ml-2 w-5 h-5" />
@@ -69,7 +79,7 @@ export default function HomePage() {
             <MotionLink
               href="/demo"
               whileHover={{ scale: 1.05 }}
-              className="inline-flex items-center justify-center px-8 py-4 bg-white/30 backdrop-blur-lg text-white rounded-2xl shadow-2xl font-semibold text-lg transition-colors glow-btn animate-ripple"
+              className="inline-flex items-center justify-center px-8 py-4 border border-accent-emerald text-accent-emerald rounded-2xl shadow-2xl font-semibold text-lg transition-colors"
             >
               <Play className="mr-2 w-5 h-5" />
               {messages.home.watchDemo}
@@ -77,15 +87,15 @@ export default function HomePage() {
           </div>
           <div className="mt-12 flex flex-wrap gap-8">
             <div className="flex items-center space-x-3">
-              <CheckCircle className="w-5 h-5 text-green-400" />
+              <CheckCircle className="w-5 h-5 text-accent-emerald" />
               <span className="text-slate-300">SOC 2 Compliant</span>
             </div>
             <div className="flex items-center space-x-3">
-              <CheckCircle className="w-5 h-5 text-green-400" />
+              <CheckCircle className="w-5 h-5 text-accent-emerald" />
               <span className="text-slate-300">$2.3B Projects Protected</span>
             </div>
             <div className="flex items-center space-x-3">
-              <CheckCircle className="w-5 h-5 text-green-400" />
+              <CheckCircle className="w-5 h-5 text-accent-emerald" />
               <span className="text-slate-300">99.9% Uptime</span>
             </div>
           </div>
@@ -95,7 +105,9 @@ export default function HomePage() {
     </div>
   </div>
   </motion.section>
-  <Testimonials className="bg-gray-50" />
+  <Suspense fallback={<Skeleton />}>
+    <Testimonials className="bg-gray-50" />
+  </Suspense>
   </>
   )
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -10,14 +10,15 @@ export default function Footer() {
     <motion.footer
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      className="glass-navbar mt-12 rounded-t-2xl py-6 flex justify-center gap-6 backdrop-blur-md"
+      className="glass-navbar bg-primary-900 mt-12 rounded-t-2xl py-6 flex justify-center gap-6 backdrop-blur-md"
     >
       {icons.map(({ href, Icon }) => (
         <motion.a
           key={href}
           href={href}
           whileHover={{ scale: 1.2, rotate: 5 }}
-          className="text-white hover:text-accent glow-btn animate-ripple rounded-full p-2"
+          aria-label="GitHub"
+          className="text-white hover:text-accent-pink glow-btn animate-ripple rounded-full p-2"
         >
           <Icon className="w-5 h-5" />
         </motion.a>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -52,7 +52,7 @@ export default function Navbar() {
         initial={{ y: -100, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ type: 'spring', stiffness: 70 }}
-        className="glass-navbar rounded-2xl shadow-2xl fixed top-0 w-full flex items-center justify-between px-8 py-4 z-50 overflow-hidden"
+        className="glass-navbar bg-primary-900/90 rounded-2xl shadow-2xl fixed top-0 w-full flex items-center justify-between px-8 py-4 z-50 overflow-hidden"
       >
         <AnimatedGradient />
         <div className="text-accent text-2xl font-bold">MyRoofGenius</div>
@@ -83,14 +83,14 @@ export default function Navbar() {
               <motion.a
                 href="/signup"
                 whileHover={{ scale: 1.05 }}
-                className="rounded-xl px-5 py-2 bg-accent text-white font-bold shadow-md transition glow-btn animate-ripple"
+                className="rounded-xl px-5 py-2 bg-accent-emerald hover:bg-accent-emerald/80 text-white font-bold shadow-md transition glow-btn animate-ripple"
               >
                 Start Free Trial
               </motion.a>
             </>
           )}
         </div>
-        <button className="md:hidden" onClick={() => setOpen(!open)}>
+        <button className="md:hidden" aria-label="Toggle menu" onClick={() => setOpen(!open)}>
           {open ? <X /> : <Menu />}
         </button>
       </motion.nav>
@@ -154,7 +154,7 @@ export default function Navbar() {
                 <motion.a
                   href="/signup"
                   whileTap={{ scale: 0.95 }}
-                  className="block px-8 py-4 border-b border-[rgba(255,255,255,0.07)] hover:text-accent glow-btn animate-ripple"
+                  className="block px-8 py-4 border-b border-[rgba(255,255,255,0.07)] hover:bg-accent-emerald/80 bg-accent-emerald text-white glow-btn animate-ripple"
                   onClick={() => setOpen(false)}
                 >
                   Start Free Trial

--- a/components/ProfileDropdown.tsx
+++ b/components/ProfileDropdown.tsx
@@ -5,6 +5,7 @@ import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import type { User } from '@supabase/supabase-js';
 import { ChevronDown } from 'lucide-react';
 import { useRole, type Role } from './ui/RoleProvider';
+import LazyImage from './ui/LazyImage';
 
 export default function ProfileDropdown() {
   const supabase = createClientComponentClient();
@@ -51,8 +52,9 @@ export default function ProfileDropdown() {
       <button
         onClick={() => setOpen(!open)}
         className="flex items-center gap-1 focus:outline-none"
+        aria-label="User menu"
       >
-        <img src={avatarUrl} alt="avatar" className="w-8 h-8 rounded-full border" />
+        <LazyImage src={avatarUrl} alt="avatar" className="w-8 h-8 rounded-full border" />
         <ChevronDown className="w-4 h-4" />
       </button>
       {open && (

--- a/components/ui/LazyImage.tsx
+++ b/components/ui/LazyImage.tsx
@@ -1,0 +1,5 @@
+'use client'
+interface LazyImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {}
+export default function LazyImage(props: LazyImageProps) {
+  return <img loading="lazy" decoding="async" {...props} />
+}

--- a/components/ui/PresenceAvatars.tsx
+++ b/components/ui/PresenceAvatars.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { usePresence } from './PresenceProvider';
+import LazyImage from './LazyImage';
 
 
 export default function PresenceAvatars() {
@@ -14,7 +15,7 @@ export default function PresenceAvatars() {
             u.name || 'U'
           )}.svg`;
         return (
-          <img
+          <LazyImage
             key={u.id}
             src={src}
             alt={u.name || 'User'}

--- a/components/ui/Skeleton.tsx
+++ b/components/ui/Skeleton.tsx
@@ -1,0 +1,3 @@
+export default function Skeleton() {
+  return <div className="animate-pulse bg-gray-200 rounded w-full h-20" />
+}

--- a/components/ui/ThemeProvider.tsx
+++ b/components/ui/ThemeProvider.tsx
@@ -17,13 +17,26 @@ const ThemeContext = createContext<ThemeCtx>({
 });
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>('dark');
+  const [theme, setTheme] = useState<Theme>(() =>
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light'
+  );
   const [accent, setAccent] = useState('#5e5ce6');
 
   useEffect(() => {
     // Load persisted theme from localStorage if available
     const stored = localStorage.getItem('theme') as Theme | null;
-    if (stored) setTheme(stored);
+    if (stored) {
+      setTheme(stored);
+    } else {
+      setTheme(
+        window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light'
+      );
+    }
     const acc = localStorage.getItem('accent');
     if (acc) setAccent(acc);
   }, []);
@@ -31,9 +44,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (typeof document === 'undefined') return;
     if (theme === 'dark') {
-      document.documentElement.classList.remove('light');
+      document.documentElement.classList.add('dark');
     } else {
-      document.documentElement.classList.add('light');
+      document.documentElement.classList.remove('dark');
     }
     // persist choice
     localStorage.setItem('theme', theme);

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -17,3 +17,5 @@ export { default as PresenceAvatars } from './PresenceAvatars';
 export { default as TypingText } from './TypingText';
 export { default as Analytics } from '../Analytics';
 export { default as HeroHeadline } from './HeroHeadline';
+export { default as Skeleton } from './Skeleton';
+export { default as LazyImage } from './LazyImage';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,16 @@ module.exports = {
           primary: '#F2F2F7',
           secondary: '#8E8E93',
         },
+        'primary-900': 'rgb(var(--clr-primary-900) / <alpha-value>)',
+        'secondary-700': 'rgb(var(--clr-secondary-700) / <alpha-value>)',
+        'accent-emerald': 'rgb(var(--clr-accent-emerald) / <alpha-value>)',
+        'accent-pink': 'rgb(var(--clr-accent-pink) / <alpha-value>)',
+      },
+      backgroundImage: {
+        'brand-gradient':
+          'linear-gradient(135deg,#0d1b2a 0%,#3f1c70 50%,#00c46b 100%)',
+        'brand-gradient-alt':
+          'linear-gradient(135deg,#3f1c70 0%,#ff7eb3 45%,#0d1b2a 100%)',
       },
       fontFamily: {
         inter: ['Inter', 'sans-serif'],


### PR DESCRIPTION
## Summary
- add new brand tokens and gradients
- map CSS variables in globals
- update ThemeProvider with system preference
- refresh Navbar, Footer and homepage hero with new palette
- create LazyImage and Skeleton components
- lazy-load carousel and testimonials

## Testing
- `npm run lint`
- `npm run test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686ea48cfd848323b42dfd59def3f0f3