### PR TITLE
perf/optimize-bundle

### DIFF
--- a/components/ProfileDropdown.tsx
+++ b/components/ProfileDropdown.tsx
@@ -54,7 +54,13 @@ export default function ProfileDropdown() {
         className="flex items-center gap-1 focus:outline-none"
         aria-label="User menu"
       >
-        <LazyImage src={avatarUrl} alt="avatar" className="w-8 h-8 rounded-full border" />
+        <LazyImage
+          src={avatarUrl}
+          alt="avatar"
+          width={32}
+          height={32}
+          className="w-8 h-8 rounded-full border"
+        />
         <ChevronDown className="w-4 h-4" />
       </button>
       {open && (

--- a/components/marketplace/MarketplaceClient.tsx
+++ b/components/marketplace/MarketplaceClient.tsx
@@ -6,13 +6,23 @@ import { motion } from "framer-motion";
 import { useEffect, useState, useCallback } from "react";
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { Search, Filter, Star, ShoppingCart, Eye } from "lucide-react";
-import ProductCarousel from "../../components/marketplace/ProductCarousel";
-import ContractorGrid from "../../components/marketplace/ContractorGrid";
+import dynamicImport from "next/dynamic";
+const ProductCarousel = dynamicImport(
+  () => import("./ProductCarousel"),
+  { ssr: false }
+);
+const ContractorGrid = dynamicImport(
+  () => import("./ContractorGrid"),
+  { ssr: false }
+);
 import {
   Product as RecommendedProduct,
   Contractor,
 } from "../../types/marketplace";
-import Testimonials from "../../components/marketing/Testimonials";
+const Testimonials = dynamicImport(
+  () => import("../marketing/Testimonials"),
+  { ssr: false }
+);
 
 const categories = [
   { id: "all", name: "All Products", icon: "🏠" },

--- a/components/ui/LazyImage.tsx
+++ b/components/ui/LazyImage.tsx
@@ -1,5 +1,6 @@
 'use client'
-interface LazyImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {}
-export default function LazyImage(props: LazyImageProps) {
-  return <img loading="lazy" decoding="async" {...props} />
+import Image, { ImageProps } from 'next/image'
+
+export default function LazyImage(props: ImageProps) {
+  return <Image loading="lazy" {...props} />
 }

--- a/next.config.js
+++ b/next.config.js
@@ -4,11 +4,19 @@ const withPWA = require('next-pwa')({
   skipWaiting: true,
   disable: process.env.NODE_ENV === 'development',
 });
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+});
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  modularizeImports: {
+    'lucide-react': {
+      transform: 'lucide-react/dist/esm/icons/{{member}}',
+    },
+  },
   images: {
     domains: [
       'localhost',
@@ -71,4 +79,4 @@ const nextConfig = {
   },
 };
 
-module.exports = withPWA(nextConfig);
+module.exports = withPWA(withBundleAnalyzer(nextConfig));

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",
     "analyze": "ANALYZE=true next build",
+    "check-bundle": "tsx scripts/check-bundle.ts",
     "playwright:install": "playwright install --with-deps chromium firefox webkit",
     "postinstall": "if [ \"$PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD\" != \"1\" ]; then npm run playwright:install; fi",
     "validate:env": "tsx scripts/validate-env.ts",

--- a/scripts/check-bundle.ts
+++ b/scripts/check-bundle.ts
@@ -1,0 +1,36 @@
+import fs from 'fs'
+import path from 'path'
+
+const manifestPath = path.join('.next', 'build-manifest.json')
+if (!fs.existsSync(manifestPath)) {
+  console.error('build-manifest.json not found. Run next build first.')
+  process.exit(1)
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<string, any>
+const pages: Record<string, string[]> = manifest.pages || {}
+let fail = false
+
+function sizeOf(files: string[]) {
+  return files
+    .filter((f) => f.endsWith('.js'))
+    .reduce((total, f) => {
+      const p = path.join('.next', f)
+      if (fs.existsSync(p)) {
+        total += fs.statSync(p).size
+      }
+      return total
+    }, 0) / 1024
+}
+
+for (const [route, files] of Object.entries(pages)) {
+  if (route.startsWith('/_')) continue
+  const kb = sizeOf(files as string[])
+  if (kb > 150) {
+    console.error(`Route ${route} JS bundle is ${kb.toFixed(1)}kb`) 
+    fail = true
+  }
+}
+
+if (fail) process.exit(1)
+else console.log('All route JS bundles within 150kb')


### PR DESCRIPTION
## Summary
- use Next.js Image for LazyImage
- dynamically load carousel and testimonial components
- tree shake lucide-react icons with modularizeImports
- add bundle analyzer with route size check

## Testing
- `npm test`
- `npm run analyze` *(fails: You are attempting to export "generateMetadata" from a component marked with "use client")*
- `npm run check-bundle` *(fails: build-manifest.json not found. Run next build first.)*

------
https://chatgpt.com/codex/tasks/task_e_686eccbf841083238a0472eee06f7b9e