### PR TITLE
Refactor theme to modern dark palette

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -18,16 +18,16 @@
   }
 
   :root {
-    --accent: 94 92 230;
-    --clr-primary-900: 13 27 42;
-    --clr-secondary-700: 63 28 112;
+    --accent: 82 118 197;
+    --clr-primary-900: 26 34 63;
+    --clr-secondary-700: 54 68 137;
     --clr-accent-emerald: 0 196 107;
-    --clr-accent-pink: 255 126 179;
+    --clr-accent-pink: 130 118 197;
     /* Brand Palette */
-    --color-primary: #006A4E;
-    --color-secondary: #F5A623;
-    --color-bg: #F4F4F4;
-    --color-text: #333333;
+    --color-primary: #1a223f;
+    --color-secondary: #5256a4;
+    --color-bg: #121212;
+    --color-text: #F2F2F7;
     --color-white: #FFFFFF;
     /* Protection Status Colors */
     --color-protected: 34 197 94;
@@ -47,10 +47,10 @@
 
   @supports not (color: oklch(0 0 0)) {
     :root {
-      --clr-primary-900: 13 27 42;
-      --clr-secondary-700: 63 28 112;
+      --clr-primary-900: 26 34 63;
+      --clr-secondary-700: 54 68 137;
       --clr-accent-emerald: 0 196 107;
-      --clr-accent-pink: 255 126 179;
+      --clr-accent-pink: 130 118 197;
     }
   }
 

--- a/components/ui/AnimatedGradient.tsx
+++ b/components/ui/AnimatedGradient.tsx
@@ -5,8 +5,8 @@ export default function AnimatedGradient() {
   return (
     <motion.div
       className="absolute inset-0 -z-10 bg-gradient-animated"
-      initial={{ opacity: 0.6 }}
-      animate={{ opacity: 1 }}
+      initial={{ opacity: 0.3 }}
+      animate={{ opacity: 0.6 }}
     />
   );
 }

--- a/components/ui/ThemeProvider.tsx
+++ b/components/ui/ThemeProvider.tsx
@@ -12,7 +12,7 @@ interface ThemeCtx {
 const ThemeContext = createContext<ThemeCtx>({
   theme: 'dark',
   toggle: () => {},
-  accent: '#5e5ce6',
+  accent: '#5276c5',
   setAccent: () => {}
 });
 
@@ -23,7 +23,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       ? 'dark'
       : 'light'
   );
-  const [accent, setAccent] = useState('#5e5ce6');
+  const [accent, setAccent] = useState('#5276c5');
 
   useEffect(() => {
     // Load persisted theme from localStorage if available

--- a/public/assets/logo.svg
+++ b/public/assets/logo.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" fill="#006A4E"/>
-  <path d="M10 70 L50 20 L90 70 Z" fill="#F5A623"/>
+  <rect width="100" height="100" fill="#2e396d"/>
+  <path d="M10 70 L50 20 L90 70 Z" fill="#8276c5"/>
 </svg>

--- a/public/badges/roof-cert.svg
+++ b/public/badges/roof-cert.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="45" fill="#006A4E"/>
+  <circle cx="50" cy="50" r="45" fill="#2e396d"/>
   <text x="50" y="55" font-size="40" text-anchor="middle" fill="white">✓</text>
 </svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,9 +23,9 @@ module.exports = {
       },
       backgroundImage: {
         'brand-gradient':
-          'linear-gradient(135deg,#0d1b2a 0%,#3f1c70 50%,#00c46b 100%)',
+          'linear-gradient(135deg,#1a223f 0%,#364489 50%,#8276c5 100%)',
         'brand-gradient-alt':
-          'linear-gradient(135deg,#3f1c70 0%,#ff7eb3 45%,#0d1b2a 100%)',
+          'linear-gradient(135deg,#364489 0%,#5256a4 45%,#1a223f 100%)',
       },
       fontFamily: {
         inter: ['Inter', 'sans-serif'],
@@ -76,7 +76,7 @@ module.exports = {
         },
         '.bg-gradient-animated': {
           background:
-            'linear-gradient(130deg, #28a745, #6c63ff, #e5b3c9, #8B5CF6, #005f9e, #28a745)',
+            'linear-gradient(130deg,#1a223f,#2e396d,#5256a4,#8276c5,#2e396d,#1a223f)',
           backgroundSize: '700% 700%',
           animation: 'gradientShift 22s ease-in-out infinite'
         }


### PR DESCRIPTION
## Summary
- refresh Tailwind palette with deep blues and violet accents
- tweak animated gradient overlay to be subtle
- update default accent color in ThemeProvider
- revise global CSS variables for new color scheme
- refresh logo and certificate badge colors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ef8ff5d6c83238bf1e6219ce19a90