### PR TITLE
Fix Poppins font import weight

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,11 @@ const ClientLayout = dynamicImport(() => import('../components/layout/ClientLayo
 export const dynamic = 'force-dynamic';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-body' });
-const poppins = Poppins({ subsets: ['latin'], variable: '--font-heading' });
+const poppins = Poppins({
+  subsets: ['latin'],
+  weight: ['400', '700'],
+  variable: '--font-heading',
+});
 const jetbrains = JetBrains_Mono({ subsets: ['latin'], variable: '--font-mono' });
 const theme = `${inter.variable} ${poppins.variable} ${jetbrains.variable}`;
 


### PR DESCRIPTION
## Summary
- specify Poppins weights in root layout to avoid build error

## Testing
- `npm run lint`
- `npm run build`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686fed2e56148323a7b72fe8397bfaef