### PR TITLE
Add starfield hero background and remove local icon references

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -5,6 +5,7 @@ import { motion } from "framer-motion";
 const MotionLink = motion(Link);
 import {
   AnimatedGradient,
+  Starfield,
   Hero3D,
   HeroHeadline,
   Skeleton,
@@ -61,6 +62,7 @@ export default function HomeClient() {
         transition={{ duration: 0.6 }}
         className="relative overflow-hidden bg-brand-gradient dark:bg-brand-gradient-alt py-24 backdrop-blur-lg rounded-2xl shadow-2xl"
       >
+        <Starfield />
         <AnimatedGradient />
         <div className="absolute top-6 right-6">
           <ActiveUsersBadge />

--- a/app/globals.css
+++ b/app/globals.css
@@ -237,3 +237,23 @@ button:focus-visible {
   max-height: 60px;
   margin: 0 0.5rem;
 }
+
+/* Hero star/galaxy background
+   Photo by Greg Rakozy on Unsplash (https://unsplash.com/photos/oMpAz-DN-9I) */
+.starfield {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(255,255,255,0.15) 1px, transparent 1px),
+    url('https://images.unsplash.com/photo-1444703686981-a3abbc4d4fe3?auto=format&fit=crop&w=1600&q=80');
+  background-size: 3px 3px, cover;
+  background-position: 0 0, center;
+  opacity: 0.5;
+  animation: starfield-move 60s linear infinite;
+  z-index: -1;
+}
+
+@keyframes starfield-move {
+  from { background-position: 0 0, center; }
+  to { background-position: 1000px 1000px, center; }
+}

--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -20,13 +20,15 @@ export default function IntegrationsPage() {
                 name: 'QuickBooks',
                 description: 'Automatic invoice sync, payment tracking, job costing',
                 status: 'active',
-                icon: '/integrations/quickbooks.svg'
+                // Icon from simple-icons CDN
+                icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/quickbooks.svg'
               },
               {
                 name: 'Stripe',
                 description: 'Payment processing with automatic reconciliation',
                 status: 'active',
-                icon: '/integrations/stripe.svg'
+                // Icon from simple-icons CDN
+                icon: 'https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/stripe.svg'
               }
             ]}
           />

--- a/components/ui/Starfield.tsx
+++ b/components/ui/Starfield.tsx
@@ -1,0 +1,5 @@
+'use client';
+export default function Starfield() {
+  return <div className="starfield" aria-hidden="true" />;
+}
+

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -21,3 +21,4 @@ export { default as Skeleton } from "./Skeleton";
 export { default as LazyImage } from "./LazyImage";
 export { default as Drawer } from "./Drawer";
 export { default as StreamingText } from "./StreamingText";
+export { default as Starfield } from "./Starfield";


### PR DESCRIPTION
## Summary
- add Starfield component and CSS for animated galaxy backdrop using Unsplash image
- restore hero background with new Starfield overlay
- use CDN hosted icons for integrations page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ffbbfbef08323ba6825c297ec700b