### PR TITLE
Phase1 initial accessibility and branding updates

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,7 +13,7 @@
   h4,
   h5,
   h6 {
-    font-family: var(--font-heading, Poppins, Inter, sans-serif);
+    font-family: var(--font-heading, 'EB Garamond', Inter, sans-serif);
   }
 
   code,
@@ -32,24 +32,24 @@
 
   :root {
     /* Core brand colors */
-    --color-primary: #1A365D;
-    --color-secondary: #38A169;
-    --color-accent: #DD6B20;
-    --color-neutral-50: #F7FAFC;
-    --color-neutral-100: #EDF2F7;
-    --color-neutral-300: #CBD5E0;
-    --color-neutral-500: #718096;
-    --color-neutral-700: #2D3748;
+    --color-primary: #005f73;
+    --color-secondary: #839788;
+    --color-accent: #d97706;
+    --color-neutral-50: #f8f7f2;
+    --color-neutral-100: #ede9dd;
+    --color-neutral-300: #d6d2c4;
+    --color-neutral-500: #839788;
+    --color-neutral-700: #262626;
     --color-bg: var(--color-neutral-50);
     --color-text: var(--color-neutral-700);
     --color-white: #ffffff;
     /* RGB counterparts for Tailwind */
-    --clr-primary-900: 26 54 93;
-    --clr-secondary-700: 56 161 105;
-    --clr-accent-orange: 221 107 32;
+    --clr-primary-900: 0 95 115;
+    --clr-secondary-700: 131 151 136;
+    --clr-accent-orange: 217 119 6;
     --clr-accent-emerald: 52 199 89;
     --clr-accent-pink: 100 108 255;
-    --accent: 221 107 32;
+    --accent: 217 119 6;
     /* Protection Status Colors */
     --color-protected: 34 197 94;
     --color-warning: 251 146 60;
@@ -68,11 +68,11 @@
 
   @supports not (color: oklch(0 0 0)) {
     :root {
-      --clr-primary-900: 26 54 93;
-      --clr-secondary-700: 56 161 105;
+      --clr-primary-900: 0 95 115;
+      --clr-secondary-700: 131 151 136;
       --clr-accent-emerald: 52 199 89;
       --clr-accent-pink: 100 108 255;
-      --accent: 221 107 32;
+      --accent: 217 119 6;
     }
   }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import './globals.css';
-import { Inter, Poppins, JetBrains_Mono } from 'next/font/google';
+import { Inter, EB_Garamond, JetBrains_Mono } from 'next/font/google';
 import type { ReactNode } from 'react';
 import dynamicImport from 'next/dynamic';
 import './lib/sentry';
@@ -12,14 +12,15 @@ const ClientLayout = dynamicImport(() => import('../components/layout/ClientLayo
 
 export const dynamic = 'force-dynamic';
 
-const inter = Inter({ subsets: ['latin'], variable: '--font-body' });
-const poppins = Poppins({
+const inter = Inter({ subsets: ['latin'], variable: '--font-body', display: 'swap' });
+const garamond = EB_Garamond({
   subsets: ['latin'],
   weight: ['400', '700'],
   variable: '--font-heading',
+  display: 'swap',
 });
 const jetbrains = JetBrains_Mono({ subsets: ['latin'], variable: '--font-mono' });
-const theme = `${inter.variable} ${poppins.variable} ${jetbrains.variable}`;
+const theme = `${inter.variable} ${garamond.variable} ${jetbrains.variable}`;
 
 export const metadata = {
   title: 'MyRoofGenius - Smart Roofing Solutions',

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -10,6 +10,7 @@ export default function LoginPage() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [magicSent, setMagicSent] = useState(false);
   const router = useRouter();
   const supabase = createClientComponentClient();
 
@@ -31,6 +32,23 @@ export default function LoginPage() {
     setLoading(false);
   };
 
+  const handleMagic = async () => {
+    setError(null);
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setError('Please enter a valid email address.');
+      return;
+    }
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
+    });
+    if (error) setError('Could not send magic link.');
+    else setMagicSent(true);
+    setLoading(false);
+  };
+
   const handleProvider = async (provider: string) => {
     setError(null);
     try {
@@ -46,6 +64,11 @@ export default function LoginPage() {
         <h1 className="text-3xl font-bold text-center">Sign in</h1>
         <form onSubmit={handleLogin} className="space-y-4">
           {error && <p className="text-red-600 text-sm" id="login-error">{error}</p>}
+          {magicSent && (
+            <p className="text-green-600 text-sm" role="status">
+              Check your email for a login link.
+            </p>
+          )}
           <label htmlFor="login-email" className="sr-only">
             Email
           </label>
@@ -78,6 +101,14 @@ export default function LoginPage() {
             className="w-full bg-accent text-white py-2 rounded"
           >
             {loading ? 'Signing in...' : 'Sign in'}
+          </button>
+          <button
+            type="button"
+            onClick={handleMagic}
+            disabled={loading}
+            className="w-full border border-gray-300 py-2 rounded text-gray-700 mt-2"
+          >
+            Send magic link
           </button>
           <button
             type="button"

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -6,6 +6,7 @@ import type { User } from '@supabase/supabase-js';
 import { motion, AnimatePresence } from 'framer-motion';
 import AnimatedGradient from './ui/AnimatedGradient';
 import { Menu, X } from 'lucide-react';
+import Image from 'next/image';
 import { ThemeToggle, AccentColorPicker, ProfileDropdown } from './ui';
 import LanguageSwitcher from './LanguageSwitcher';
 import CurrencySwitcher from './CurrencySwitcher';
@@ -57,7 +58,13 @@ export default function Navbar() {
         <AnimatedGradient />
         <div className="flex items-center gap-3">
           <a href="/" className="flex items-center" aria-label="MyRoofGenius">
-            <img src="/assets/logo.svg" alt="MyRoofGenius logo" className="w-8 h-8" />
+            <Image
+              src="/assets/logo.svg"
+              alt="MyRoofGenius logo"
+              width={32}
+              height={32}
+              loading="lazy"
+            />
           </a>
           <p className="hidden sm:block text-sm text-white font-semibold">
             Smart Roofing Solutions

--- a/components/marketing/TrustSection.tsx
+++ b/components/marketing/TrustSection.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Image from "next/image";
 export default function TrustSection() {
   return (
     <section className="trust">
@@ -7,7 +8,13 @@ export default function TrustSection() {
         "MyRoofGenius saved us $20k on project estimates!" – John, ABC Roofing
       </blockquote>
       <div className="badges">
-        <img src="/badges/roof-cert.svg" alt="Roofing Certified badge" />
+        <Image
+          src="/badges/roof-cert.svg"
+          alt="Roofing Certified badge"
+          width={80}
+          height={80}
+          loading="lazy"
+        />
       </div>
     </section>
   );

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  preset: 'ts-jest/presets/js-with-ts',
+  preset: 'ts-jest',
   testEnvironment: 'jsdom',
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   transform: {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,2 @@
-require('@testing-library/jest-dom')
+require('@testing-library/jest-dom');
+require('jest-axe/extend-expect');

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "husky": "^8.0.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.0.3",
+        "jest-axe": "^10.0.0",
         "jest-environment-jsdom": "^30.0.2",
         "lighthouse": "^12.7.1",
         "lint-staged": "^15.2.0",
@@ -9543,6 +9544,16 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
     },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -13102,6 +13113,136 @@
         }
       }
     },
+    "node_modules/jest-axe": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-10.0.0.tgz",
+      "integrity": "sha512-9QR0M7//o5UVRnEUUm68IsGapHrcKGakYy9dKWWMX79LmeUKguDI6DREyljC5I13j78OUmtKLF5My6ccffLFBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axe-core": "4.10.2",
+        "chalk": "4.1.2",
+        "jest-matcher-utils": "29.2.2",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-axe/node_modules/axe-core": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
+      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-axe/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-axe/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/jest-matcher-utils": {
+      "version": "29.2.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.2.tgz",
+      "integrity": "sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-axe/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jest-changed-files": {
       "version": "30.0.2",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.0.2.tgz",
@@ -13541,6 +13682,16 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-haste-map": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "husky": "^8.0.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.0.3",
+    "jest-axe": "^10.0.0",
     "jest-environment-jsdom": "^30.0.2",
     "lighthouse": "^12.7.1",
     "lint-staged": "^15.2.0",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -4,8 +4,8 @@
   "description": "Access MyRoofGenius tools offline and on site.",
   "start_url": "/",
   "display": "standalone",
-  "theme_color": "#0d1b2a",
-  "background_color": "#0d1b2a",
+  "theme_color": "#005f73",
+  "background_color": "#f8f7f2",
   "icons": [
     { "src": "https://via.placeholder.com/192", "sizes": "192x192", "type": "image/png" },
     { "src": "https://via.placeholder.com/512", "sizes": "512x512", "type": "image/png" },

--- a/public/offline.html
+++ b/public/offline.html
@@ -58,7 +58,7 @@
   </style>
 </head>
 <body>
-  <div class="container">
+  <main class="container" role="main">
     <div class="icon">
       <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="#64748b" stroke-width="2">
         <path d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
@@ -77,7 +77,7 @@
       ✓ Use calculation tools
     </div>
     <a href="/dashboard" class="button">Continue Working</a>
-  </div>
+  </main>
   <script>
     setInterval(() => {
       fetch('/api/health', { method: 'HEAD' })

--- a/tests/accessibility/offline.a11y.test.ts
+++ b/tests/accessibility/offline.a11y.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'fs';
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder as any;
+global.TextDecoder = TextDecoder as any;
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+expect.extend(toHaveNoViolations);
+
+test('offline.html is accessible', async () => {
+  const html = readFileSync('public/offline.html', 'utf8');
+  const results = await axe(html);
+  expect(results).toHaveNoViolations();
+});

--- a/tests/layout.spec.tsx
+++ b/tests/layout.spec.tsx
@@ -7,7 +7,7 @@ jest.mock('../app/lib/sentry', () => ({}));
 jest.mock('@vercel/analytics/react', () => ({ Analytics: () => null }));
 jest.mock('next/font/google', () => ({
   Inter: () => ({ className: 'font', variable: '--font-body' }),
-  Poppins: () => ({ className: 'font', variable: '--font-heading' }),
+  EB_Garamond: () => ({ className: 'font', variable: '--font-heading' }),
   JetBrains_Mono: () => ({ className: 'font', variable: '--font-mono' }),
 }));
 jest.mock('next/dynamic', () => () => () => null);


### PR DESCRIPTION
## Summary
- integrate EB Garamond heading font and Inter body font
- update color tokens to new Trust & Tech palette
- add magic link auth option
- lazy-load logos and badges
- add offline page landmark for a11y
- include jest-axe accessibility test

## Testing
- `npm test`
- `npm run lint`
- `npm run lighthouse:seo` *(fails: ChromePathNotSetError)*


------
https://chatgpt.com/codex/tasks/task_e_68701796e1d48323bace369afe80d962