### PR TITLE
Fix header visuals and restore background gradient

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    @apply bg-bg text-text-primary font-sans;
+    @apply bg-gradient-animated text-text-primary font-sans;
   }
 
   h1,
@@ -21,7 +21,6 @@
     font-family: var(--font-mono, "JetBrains Mono", monospace);
   }
 
-  body,
   footer,
   .btn-green,
   .banner {

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,11 +1,12 @@
 'use client';
+import Link from 'next/link';
 
 export default function NotFound() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-bg text-text-primary">
       <h1 className="text-3xl font-bold mb-2">Page Not Found</h1>
       <p className="text-text-secondary mb-6">You’ve reached an invalid page, but your estimate is still just one click away.</p>
-      <a href="/" className="btn-accent px-6 py-2 rounded-xl font-bold">Return Home</a>
+      <Link href="/" className="btn-accent px-6 py-2 rounded-xl font-bold">Return Home</Link>
     </div>
   );
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import type { User } from '@supabase/supabase-js';
 import { motion, AnimatePresence } from 'framer-motion';
-import AnimatedGradient from './ui/AnimatedGradient';
+import Link from 'next/link';
 import { Menu, X } from 'lucide-react';
 import Image from 'next/image';
 import { ThemeToggle, AccentColorPicker, ProfileDropdown } from './ui';
@@ -53,11 +53,10 @@ export default function Navbar() {
         initial={{ y: -100, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ type: 'spring', stiffness: 70 }}
-        className="glass-navbar bg-primary-900/90 rounded-2xl shadow-2xl fixed top-0 w-full flex items-center justify-between px-8 py-4 z-50 overflow-hidden"
+        className="bg-black rounded-2xl shadow-2xl fixed top-0 w-full flex items-center justify-between px-8 py-4 z-50"
       >
-        <AnimatedGradient />
         <div className="flex items-center gap-3">
-          <a href="/" className="flex items-center" aria-label="MyRoofGenius">
+          <Link href="/" className="flex items-center" aria-label="MyRoofGenius">
             <Image
               src="/assets/logo.svg"
               alt="MyRoofGenius logo"
@@ -65,7 +64,7 @@ export default function Navbar() {
               height={32}
               loading="lazy"
             />
-          </a>
+          </Link>
           <p className="hidden sm:block text-sm text-white font-semibold">
             Smart Roofing Solutions
           </p>
@@ -110,13 +109,12 @@ export default function Navbar() {
       </motion.nav>
       <AnimatePresence>
         {open && (
-          <motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            className="md:hidden bg-[rgba(35,35,35,0.9)] backdrop-blur-xl border-b border-[rgba(255,255,255,0.07)] rounded-b-2xl shadow-2xl fixed top-16 w-full z-40 overflow-hidden"
-          >
-            <AnimatedGradient />
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              className="md:hidden bg-black backdrop-blur-xl rounded-b-2xl shadow-2xl fixed top-16 w-full z-40 overflow-hidden"
+            >
             {links.map(({ href, label }) => (
               <motion.a
                 key={href}

--- a/components/layout/AnimatedLayout.tsx
+++ b/components/layout/AnimatedLayout.tsx
@@ -8,7 +8,7 @@ export default function AnimatedLayout({ children }: { children: ReactNode }) {
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="bg-black/15 backdrop-blur-md rounded-2xl shadow-2xl min-h-screen text-text-primary font-sans relative overflow-hidden"
+      className="backdrop-blur-md rounded-2xl shadow-2xl min-h-screen text-text-primary font-sans relative overflow-hidden"
     >
       <AnimatedGradient />
       {children}

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,6 +1,7 @@
 import { NextPageContext } from 'next';
 import * as Sentry from '@sentry/nextjs';
 import { sendAlert } from '../app/lib/notify';
+import Link from 'next/link';
 
 function Error({ statusCode }: { statusCode: number | undefined }) {
   const message = statusCode
@@ -10,7 +11,7 @@ function Error({ statusCode }: { statusCode: number | undefined }) {
     <div className="min-h-screen flex flex-col items-center justify-center gap-4 p-4">
       <h1 className="text-2xl font-bold">Something went wrong</h1>
       <p className="text-gray-600">{message}</p>
-      <a href="/" className="text-secondary-700 hover:underline">Return Home</a>
+      <Link href="/" className="text-secondary-700 hover:underline">Return Home</Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove gradient overlay from header and mobile menu
- set Navbar background to pure black
- restore animated gradient site background
- ensure internal links use `next/link`

## Testing
- `npm run lint`
- `npm test`
- `npx lighthouse` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_68707b402130832390042f6f570aa90b