### PR TITLE
Fix brand colors and reveal hero starfield

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -73,7 +73,7 @@ export default function HomeClient() {
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.6 }}
-        className="relative overflow-hidden bg-brand-gradient dark:bg-brand-gradient-alt py-24 backdrop-blur-lg rounded-2xl shadow-2xl"
+        className="relative overflow-hidden bg-black/20 py-24 backdrop-blur-lg rounded-2xl shadow-2xl"
       >
         <AnimatedGradient />
         <div className="absolute top-6 right-6">
@@ -82,7 +82,7 @@ export default function HomeClient() {
         <div className="container relative mx-auto px-4 max-w-6xl">
           <div className="max-w-3xl">
             <div className="inline-flex items-center space-x-2 bg-white/30 backdrop-blur-lg rounded-full shadow-2xl px-4 py-2 mb-8">
-              <Shield className="w-5 h-5 text-accent-emerald" />
+              <Shield className="w-5 h-5 text-primary" />
               <span className="text-sm font-medium text-white">
                 Trusted by 2,800+ contractors
               </span>
@@ -95,21 +95,21 @@ export default function HomeClient() {
             >
               <HeroHeadline
                 texts={["Protect every project.", "Grow every margin."]}
-                className="text-accent-pink"
+                className="text-accent"
               />
             </motion.h1>
             <ul className="text-slate-300 mb-8 space-y-2">
               <li className="flex items-start gap-2">
-                <CheckCircle className="w-5 h-5 text-accent-emerald" />
-                Instant AI estimates
+                <CheckCircle className="w-5 h-5 text-primary" />
+              Instant AI estimates
               </li>
               <li className="flex items-start gap-2">
-                <CheckCircle className="w-5 h-5 text-accent-pink" />
-                Error-proof templates
+                <CheckCircle className="w-5 h-5 text-accent" />
+              Error-proof templates
               </li>
               <li className="flex items-start gap-2">
-                <CheckCircle className="w-5 h-5 text-accent-emerald" />
-                Mobile field tools
+                <CheckCircle className="w-5 h-5 text-primary" />
+              Mobile field tools
               </li>
             </ul>
             <Hero3D />
@@ -122,7 +122,7 @@ export default function HomeClient() {
               <MotionLink
                 href="/get-started"
                 whileHover={{ scale: 1.05 }}
-                className="inline-flex items-center justify-center px-8 py-4 bg-accent-emerald hover:bg-accent-emerald/80 text-white rounded-2xl shadow-2xl font-semibold text-lg transition-colors glow-btn animate-ripple"
+                className="inline-flex items-center justify-center px-8 py-4 bg-accent hover:bg-accent/80 text-white rounded-2xl shadow-2xl font-semibold text-lg transition-colors glow-btn animate-ripple"
               >
                 {messages.home.startTrial}
                 <ArrowRight className="ml-2 w-5 h-5" />
@@ -130,7 +130,7 @@ export default function HomeClient() {
               <MotionLink
                 href="/demo"
                 whileHover={{ scale: 1.05 }}
-                className="inline-flex items-center justify-center px-8 py-4 border border-accent-emerald text-accent-emerald hover:text-accent-pink hover:border-accent-pink rounded-2xl shadow-2xl font-semibold text-lg transition-colors"
+                className="inline-flex items-center justify-center px-8 py-4 border border-primary text-primary hover:bg-primary hover:text-white rounded-2xl shadow-2xl font-semibold text-lg transition-colors"
               >
                 <Play className="mr-2 w-5 h-5" />
                 {messages.home.watchDemo}
@@ -157,7 +157,7 @@ export default function HomeClient() {
         </div>
       </motion.section>
       <Suspense fallback={<Skeleton />}>
-        <Testimonials className="bg-gray-50" />
+        <Testimonials className="bg-bg" />
       </Suspense>
       <Suspense fallback={<Skeleton />}>
         <TrustSection />

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -62,10 +62,10 @@ export default function AdminSettings() {
             onChange={e => toggle(flag.key, e.target.checked)}
           />
           <span className="font-medium">{flag.label}</span>
-          <span className="text-sm text-gray-500">{flag.description}</span>
+          <span className="text-sm text-text-secondary">{flag.description}</span>
         </label>
       ))}
-      <p className="text-sm text-gray-500">
+      <p className="text-sm text-text-secondary">
         Changes apply on next page load and are stored in localStorage.
       </p>
     </div>

--- a/app/ar/page.tsx
+++ b/app/ar/page.tsx
@@ -14,7 +14,7 @@ export default function ARDemoPage() {
     <div className="p-6 space-y-4">
       <h1 className="text-2xl font-bold">AR Model Demo</h1>
       <RemoteModelViewer src={modelUrl} iosSrc={iosUrl} className="w-full h-80 rounded-lg" />
-      <p className="text-sm text-gray-500">This demo loads a remote 3D model only.</p>
+      <p className="text-sm text-text-secondary">This demo loads a remote 3D model only.</p>
     </div>
   );
 }

--- a/app/auth/setup-guide.tsx
+++ b/app/auth/setup-guide.tsx
@@ -94,9 +94,9 @@ export default async function BlogPost({ params }: { params: { slug: string } })
       <article className="max-w-4xl mx-auto px-4 py-12">
         {/* Breadcrumb */}
         <nav className="mb-8 text-sm">
-          <Link href="/" className="text-gray-500 hover:text-gray-700">Home</Link>
+          <Link href="/" className="text-text-secondary hover:text-gray-700">Home</Link>
           <span className="mx-2 text-gray-400">/</span>
-          <Link href="/blog" className="text-gray-500 hover:text-gray-700">Blog</Link>
+          <Link href="/blog" className="text-text-secondary hover:text-gray-700">Blog</Link>
           <span className="mx-2 text-gray-400">/</span>
           <span className="text-gray-900">{post.category}</span>
         </nav>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -131,11 +131,11 @@ export default async function BlogPost({
       <article className="max-w-4xl mx-auto px-4 py-12">
         {/* Breadcrumb */}
         <nav className="mb-8 text-sm">
-          <Link href="/" className="text-gray-500 hover:text-gray-700">
+          <Link href="/" className="text-text-secondary hover:text-gray-700">
             Home
           </Link>
           <span className="mx-2 text-gray-400">/</span>
-          <Link href="/blog" className="text-gray-500 hover:text-gray-700">
+          <Link href="/blog" className="text-text-secondary hover:text-gray-700">
             Blog
           </Link>
           <span className="mx-2 text-gray-400">/</span>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -127,7 +127,7 @@ export default async function Blog() {
                   </Link>
                 </h2>
                 <p className="text-gray-600 mb-6 text-lg">{posts[0].excerpt}</p>
-                <div className="flex items-center gap-4 text-sm text-gray-500">
+                <div className="flex items-center gap-4 text-sm text-text-secondary">
                   <span>{posts[0].author}</span>
                   <span>•</span>
                   <span>
@@ -175,7 +175,7 @@ export default async function Blog() {
                     </Link>
                   </h3>
                   <p className="text-gray-600 mb-4">{post.excerpt}</p>
-                  <div className="flex items-center gap-4 text-sm text-gray-500">
+                  <div className="flex items-center gap-4 text-sm text-text-secondary">
                     <span>{post.author}</span>
                     <span>•</span>
                     <span>{post.read_time}</span>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -424,7 +424,7 @@ export default async function Dashboard() {
                         <p className="text-sm font-medium truncate">
                           {download.product_files?.file_name}
                         </p>
-                        <p className="text-xs text-gray-500">
+                        <p className="text-xs text-text-secondary">
                           {new Date(download.created_at).toLocaleDateString()}
                         </p>
                       </div>
@@ -478,7 +478,7 @@ export default async function Dashboard() {
                           <p className="text-sm font-medium">
                             {analysis.analysis_type} Analysis
                           </p>
-                          <p className="text-xs text-gray-500">
+                          <p className="text-xs text-text-secondary">
                             {new Date(analysis.created_at).toLocaleDateString()}
                           </p>
                           <p className="text-xs text-gray-600 mt-1">
@@ -521,7 +521,7 @@ export default async function Dashboard() {
                           <p className="text-sm font-medium">
                             {fav.products?.name}
                           </p>
-                          <p className="text-xs text-gray-500">${fav.products?.price?.toFixed(2)}</p>
+                          <p className="text-xs text-text-secondary">${fav.products?.price?.toFixed(2)}</p>
                         </div>
                       </div>
                     ))}
@@ -552,7 +552,7 @@ export default async function Dashboard() {
                           <p className="text-sm font-medium line-clamp-1">
                             {ticket.subject}
                           </p>
-                          <p className="text-xs text-gray-500">
+                          <p className="text-xs text-text-secondary">
                             {ticket.status} • {new Date(ticket.created_at).toLocaleDateString()}
                           </p>
                         </div>

--- a/app/demo/DemoClient.tsx
+++ b/app/demo/DemoClient.tsx
@@ -48,7 +48,7 @@ export default function DemoClient() {
           <h1 className="text-4xl md:text-5xl font-bold text-slate-900 mb-6">
             See Protection in Action
           </h1>
-          <p className="text-xl text-slate-600 max-w-3xl mx-auto">
+          <p className="text-xl text-text-secondary max-w-3xl mx-auto">
             Watch how MyRoofGenius protects professionals from the failures
             that derail projects and destroy margins.
           </p>
@@ -78,7 +78,7 @@ export default function DemoClient() {
           </div>
           <div className="p-8">
             <h2 className="text-2xl font-bold mb-3">{demos[activeDemo].title}</h2>
-            <p className="text-lg text-slate-600 mb-6">{demos[activeDemo].description}</p>
+            <p className="text-lg text-text-secondary mb-6">{demos[activeDemo].description}</p>
             <div className="space-y-3">
               {demos[activeDemo].keyPoints.map((point, i) => (
                 <div key={i} className="flex items-center">
@@ -119,7 +119,7 @@ function ROIMetric({ icon, label, value, description }) {
       </div>
       <div className="text-3xl font-bold text-secondary-700 mb-2">{value}</div>
       <div className="font-semibold text-slate-900 mb-1">{label}</div>
-      <div className="text-sm text-slate-600">{description}</div>
+      <div className="text-sm text-text-secondary">{description}</div>
     </div>
   )
 }

--- a/app/field-apps/page.tsx
+++ b/app/field-apps/page.tsx
@@ -20,7 +20,7 @@ export default function FieldAppsPage() {
           <h1 className="text-4xl md:text-5xl font-bold text-slate-900 mb-6">
             Field Apps: Your Mobile Command Center
           </h1>
-          <p className="text-xl text-slate-600 max-w-3xl mx-auto leading-relaxed">
+          <p className="text-xl text-text-secondary max-w-3xl mx-auto leading-relaxed">
             When you&apos;re on a roof at 7 AM with a decision to make, you need systems
             that work with one bar of signal and gloves on. Built for real conditions,
             not ideal ones.
@@ -36,21 +36,21 @@ export default function FieldAppsPage() {
                 <WifiOff className="w-8 h-8 text-accent-emerald" />
               </div>
               <h3 className="font-semibold text-lg mb-2">Lost Work Prevention</h3>
-              <p className="text-slate-600">Offline-first architecture. Every photo, note, and measurement saves locally first.</p>
+              <p className="text-text-secondary">Offline-first architecture. Every photo, note, and measurement saves locally first.</p>
             </div>
             <div className="text-center">
               <div className="w-16 h-16 bg-accent-emerald/20 rounded-full flex items-center justify-center mx-auto mb-4">
                 <Camera className="w-8 h-8 text-accent-emerald" />
               </div>
               <h3 className="font-semibold text-lg mb-2">Proof of Work</h3>
-              <p className="text-slate-600">Photos and notes automatically attach to the job record, even without service.</p>
+              <p className="text-text-secondary">Photos and notes automatically attach to the job record, even without service.</p>
             </div>
             <div className="text-center">
               <div className="w-16 h-16 bg-accent-emerald/20 rounded-full flex items-center justify-center mx-auto mb-4">
                 <FileText className="w-8 h-8 text-accent-emerald" />
               </div>
               <h3 className="font-semibold text-lg mb-2">Simplified Reporting</h3>
-              <p className="text-slate-600">Generate clean reports from the field with one tap, gloves on.</p>
+              <p className="text-text-secondary">Generate clean reports from the field with one tap, gloves on.</p>
             </div>
           </div>
         </div>

--- a/app/get-started/page.tsx
+++ b/app/get-started/page.tsx
@@ -14,7 +14,7 @@ export default function GetStarted() {
         <h1 className="text-4xl font-bold text-slate-900 mb-4">Start Your Free Trial</h1>
         <p className="text-lg text-slate-700 mb-6">Create your account to access professional roofing calculators and templates.</p>
         <Link href="/signup" className="inline-block bg-secondary-700 text-white px-8 py-3 rounded-lg font-semibold hover:bg-secondary-700/80 transition-colors">Create Account</Link>
-        <p className="mt-4 text-sm text-slate-600">Already have an account? <Link href="/login" className="text-secondary-700 underline">Sign in</Link></p>
+        <p className="mt-4 text-sm text-text-secondary">Already have an account? <Link href="/login" className="text-secondary-700 underline">Sign in</Link></p>
       </div>
     </div>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    @apply bg-gradient-animated text-text-primary font-sans;
+    @apply bg-bg text-text-primary font-sans;
   }
 
   h1,
@@ -62,6 +62,11 @@
     --shadow-protected: 0 0 0 3px rgba(34, 197, 94, 0.1);
     --shadow-warning: 0 0 0 3px rgba(251, 146, 60, 0.1);
     --shadow-danger: 0 0 0 3px rgba(239, 68, 68, 0.1);
+  }
+
+  .dark :root {
+    --color-bg: #121212;
+    --color-text: #ede9dd;
   }
 
   @supports not (color: oklch(0 0 0)) {

--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -7,7 +7,7 @@ export default function IntegrationsPage() {
         <h1 className="text-4xl font-bold text-center mb-4">
           Your Systems, Connected and Protected
         </h1>
-        <p className="text-xl text-center text-slate-600 mb-12 max-w-3xl mx-auto">
+        <p className="text-xl text-center text-text-secondary mb-12 max-w-3xl mx-auto">
           MyRoofGenius connects with the tools you already use, creating a protective 
           network that catches issues before they cascade.
         </p>
@@ -42,14 +42,14 @@ function IntegrationCategory({ title, description, integrations }) {
   return (
     <div>
       <h2 className="text-2xl font-semibold mb-2">{title}</h2>
-      <p className="text-slate-600 mb-4">{description}</p>
+      <p className="text-text-secondary mb-4">{description}</p>
       <div className="grid md:grid-cols-2 gap-6">
         {integrations.map((intg, i) => (
           <div key={i} className="bg-white rounded-lg shadow p-4 flex items-center space-x-4">
             <Image src={intg.icon} alt={intg.name} width={48} height={48} className="w-12 h-12" />
             <div className="flex-1">
               <h3 className="font-semibold">{intg.name}</h3>
-              <p className="text-sm text-slate-600">{intg.description}</p>
+              <p className="text-sm text-text-secondary">{intg.description}</p>
             </div>
             <span className="text-sm text-accent-emerald font-medium">{intg.status}</span>
           </div>

--- a/app/product/[id]/CheckoutButton.tsx
+++ b/app/product/[id]/CheckoutButton.tsx
@@ -69,7 +69,7 @@ export default function CheckoutButton({ priceId, productId }: CheckoutButtonPro
         {loading ? 'Processing...' : 'Buy Now'}
       </button>
       {error && <p className="text-sm text-red-600">{error}</p>}
-      <p className="flex items-center justify-center text-xs text-gray-500 gap-1">
+      <p className="flex items-center justify-center text-xs text-text-secondary gap-1">
         <Lock className="w-4 h-4" /> Secure checkout powered by Stripe
       </p>
     </div>

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -102,9 +102,9 @@ export default async function ProductPage({ params }: { params: { id: string } }
       <div className="max-w-7xl mx-auto px-4 py-8">
         {/* Breadcrumb */}
         <nav className="mb-8 text-sm">
-          <Link href="/" className="text-gray-500 hover:text-gray-700">Home</Link>
+          <Link href="/" className="text-text-secondary hover:text-gray-700">Home</Link>
           <span className="mx-2 text-gray-400">/</span>
-          <Link href="/marketplace" className="text-gray-500 hover:text-gray-700">Marketplace</Link>
+          <Link href="/marketplace" className="text-text-secondary hover:text-gray-700">Marketplace</Link>
           <span className="mx-2 text-gray-400">/</span>
           <span className="text-gray-900">{product.name}</span>
         </nav>
@@ -154,7 +154,7 @@ export default async function ProductPage({ params }: { params: { id: string } }
                 <div>
                   <span className="text-4xl font-bold">${product.price}</span>
                   {product.original_price && (
-                    <span className="text-xl text-gray-500 line-through ml-3">
+                    <span className="text-xl text-text-secondary line-through ml-3">
                       ${product.original_price}
                     </span>
                   )}
@@ -231,7 +231,7 @@ export default async function ProductPage({ params }: { params: { id: string } }
                 &quot;This tool paid for itself on the first project. Found $8,000 in hidden costs I would have missed.&quot;
               </p>
               <p className="font-semibold">Mike R. - Denver, CO</p>
-              <p className="text-sm text-gray-500">Verified Purchase</p>
+              <p className="text-sm text-text-secondary">Verified Purchase</p>
             </div>
             <div className="bg-white p-6 rounded-lg shadow">
               <div className="flex text-yellow-400 mb-2">
@@ -243,7 +243,7 @@ export default async function ProductPage({ params }: { params: { id: string } }
                 &quot;Finally, someone who understands commercial roofing. This is exactly what I&apos;ve been looking for.&quot;
               </p>
               <p className="font-semibold">Sarah T. - Colorado Springs</p>
-              <p className="text-sm text-gray-500">Verified Purchase</p>
+              <p className="text-sm text-text-secondary">Verified Purchase</p>
             </div>
           </div>
         </section>

--- a/app/tools/ToolsClient.tsx
+++ b/app/tools/ToolsClient.tsx
@@ -68,7 +68,7 @@ export default function ToolsClient() {
           <h1 className="text-4xl md:text-5xl font-bold text-slate-900 mb-6">
             Professional Tools That Protect Your Business
           </h1>
-          <p className="text-xl text-slate-600 max-w-3xl mx-auto">
+          <p className="text-xl text-text-secondary max-w-3xl mx-auto">
             Every calculation here was built from hard lessons. These aren&apos;t just tools –
             they&apos;re protection against the mistakes that sink projects.
           </p>
@@ -79,7 +79,7 @@ export default function ToolsClient() {
           <div key={idx} className="mb-16">
             <div className="mb-8">
               <h2 className="text-3xl font-bold text-slate-900 mb-3">{category.category}</h2>
-              <p className="text-lg text-slate-600">{category.description}</p>
+              <p className="text-lg text-text-secondary">{category.description}</p>
             </div>
             <div className="grid md:grid-cols-2 gap-6">
               {category.tools.map((tool, toolIdx) => (
@@ -90,7 +90,7 @@ export default function ToolsClient() {
         ))}
 
         {/* Integration Section */}
-        <div className="bg-secondary-700/5 rounded-2xl p-8 mt-16">
+        <div className="bg-secondary/5 rounded-2xl p-8 mt-16">
           <h2 className="text-2xl font-bold mb-4">All Tools Work Together</h2>
           <p className="text-slate-700 mb-6">
             Your calculations flow seamlessly between tools. Estimate materials,
@@ -126,7 +126,7 @@ function ToolCard({ name, description, features, link, icon, saveTime }) {
         </span>
       </div>
       <h3 className="text-xl font-bold mb-2">{name}</h3>
-      <p className="text-slate-600 mb-4">{description}</p>
+      <p className="text-text-secondary mb-4">{description}</p>
       <ul className="space-y-2 mb-6">
         {features.map((feature, i) => (
           <motion.li

--- a/app/tools/photo-analyzer/page.tsx
+++ b/app/tools/photo-analyzer/page.tsx
@@ -38,7 +38,7 @@ export default function PhotoAnalyzerPage() {
         className="mt-2 w-full text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer focus:ring-2 focus:ring-offset-2 focus:ring-accent-emerald"
         aria-describedby="upload-desc"
       />
-      <p id="upload-desc" className="text-sm text-gray-500 mt-2">
+      <p id="upload-desc" className="text-sm text-text-secondary mt-2">
         Drag and drop or select a roof image (JPG/PNG)
       </p>
       <div id="upload-status" aria-live="polite" className="mt-2">

--- a/components/AIEstimator.tsx
+++ b/components/AIEstimator.tsx
@@ -237,7 +237,7 @@ export default function AIEstimator() {
                 <p className="font-semibold mb-2">
                   {isDragActive ? 'Drop the photo here' : 'Drag & drop a roof photo'}
                 </p>
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-text-secondary">
                   or click to select from your device
                 </p>
                 <p className="text-xs text-gray-400 mt-2">
@@ -251,7 +251,7 @@ export default function AIEstimator() {
                   <>
                     <Camera className="w-12 h-12 mx-auto mb-4 text-gray-400" />
                     <p className="font-semibold mb-2">Take a Photo</p>
-                    <p className="text-sm text-gray-500 mb-4">
+                    <p className="text-sm text-text-secondary mb-4">
                       Use your device camera for instant capture
                     </p>
                     <Button onClick={startCamera} variant="secondary" size="sm">
@@ -331,7 +331,7 @@ export default function AIEstimator() {
             </div>
             <h3 className="text-xl font-semibold mb-2">Analyzing Your Roof...</h3>
             <p className="text-gray-600">Our AI is examining the image for:</p>
-            <ul className="mt-4 space-y-2 text-sm text-gray-500">
+            <ul className="mt-4 space-y-2 text-sm text-text-secondary">
               <li>✓ Roof dimensions and square footage</li>
               <li>✓ Material type and condition</li>
               <li>✓ Visible damage or wear</li>
@@ -362,7 +362,7 @@ export default function AIEstimator() {
                   {result.square_feet?.toLocaleString()}
                 </p>
                 {typeof result.confidence_scores?.area_measurement === 'number' && (
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-text-secondary">
                     {(result.confidence_scores.area_measurement * 100).toFixed(0)}% confidence
                   </p>
                 )}
@@ -373,7 +373,7 @@ export default function AIEstimator() {
                   {result.material || 'Unknown'}
                 </p>
                 {typeof result.confidence_scores?.material_identification === 'number' && (
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-text-secondary">
                     {(result.confidence_scores.material_identification * 100).toFixed(0)}% confidence
                   </p>
                 )}
@@ -413,7 +413,7 @@ export default function AIEstimator() {
                 <p className="text-2xl font-bold">
                   {result.estimated_remaining_life?.toLocaleString()}
                 </p>
-                <p className="text-xs text-gray-500">years estimated</p>
+                <p className="text-xs text-text-secondary">years estimated</p>
               </div>
             </div>
 
@@ -450,7 +450,7 @@ export default function AIEstimator() {
               <div className="border rounded-lg p-6">
                 <h3 className="font-semibold mb-2">Identified Issues</h3>
                 {typeof result.confidence_scores?.damage_assessment === 'number' && (
-                  <p className="text-xs text-gray-500 mb-4">
+                  <p className="text-xs text-text-secondary mb-4">
                     {(result.confidence_scores.damage_assessment * 100).toFixed(0)}% confidence
                   </p>
                 )}

--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -139,7 +139,7 @@ function OverviewTab({ stats }: { stats: DashboardStats }) {
             </LineChart>
           </ResponsiveContainer>
         ) : (
-          <p className="text-gray-500">No revenue data available.</p>
+          <p className="text-text-secondary">No revenue data available.</p>
         )}
       </div>
     </div>
@@ -283,7 +283,7 @@ function ProductsTab() {
                     <Image src={product.image_url} alt={product.name} width={40} height={40} className="w-10 h-10 rounded object-cover mr-3" />
                     <div>
                       <p className="font-medium">{product.name}</p>
-                      <p className="text-xs text-gray-500">{product.description?.slice(0, 50)}...</p>
+                      <p className="text-xs text-text-secondary">{product.description?.slice(0, 50)}...</p>
                     </div>
                   </div>
                 </td>
@@ -463,7 +463,7 @@ function AnalyticsTab({ stats }: { stats: DashboardStats }) {
           ))}
         </div>
       ) : (
-        <p className="text-gray-500">Not enough data to display analytics.</p>
+        <p className="text-text-secondary">Not enough data to display analytics.</p>
       )}
     </div>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -15,12 +15,12 @@ export default function Footer() {
     <motion.footer
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      className="glass-navbar bg-primary-900 mt-12 rounded-t-2xl py-6 flex flex-col items-center gap-4 backdrop-blur-md"
+      className="glass-navbar bg-primary mt-12 rounded-t-2xl py-6 flex flex-col items-center gap-4 backdrop-blur-md"
     >
       <p className="text-white text-sm">©2025 MyRoofGenius • Smart Roofing Solutions</p>
       <nav className="flex gap-6 text-sm text-white">
         {links.map(({ href, label }) => (
-          <a key={href} href={href} className="hover:text-accent-pink">
+          <a key={href} href={href} className="hover:text-accent">
             {label}
           </a>
         ))}
@@ -32,7 +32,7 @@ export default function Footer() {
             href={href}
             whileHover={{ scale: 1.2, rotate: 5 }}
             aria-label="GitHub"
-            className="text-white hover:text-accent-pink glow-btn animate-ripple rounded-full p-2"
+            className="text-white hover:text-accent glow-btn animate-ripple rounded-full p-2"
           >
             <Icon className="w-5 h-5" />
           </motion.a>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -96,7 +96,7 @@ export default function Navbar() {
               <motion.a
                 href="/signup"
                 whileHover={{ scale: 1.05 }}
-                className="rounded-xl px-5 py-2 bg-accent-emerald hover:bg-accent-emerald/80 text-white font-bold shadow-md transition glow-btn animate-ripple"
+                className="rounded-xl px-5 py-2 bg-accent hover:bg-accent/80 text-white font-bold shadow-md transition glow-btn animate-ripple"
               >
                 Start Free Trial
               </motion.a>
@@ -166,7 +166,7 @@ export default function Navbar() {
                 <motion.a
                   href="/signup"
                   whileTap={{ scale: 0.95 }}
-                  className="block px-8 py-4 border-b border-[rgba(255,255,255,0.07)] hover:bg-accent-emerald/80 bg-accent-emerald text-white glow-btn animate-ripple"
+                  className="block px-8 py-4 border-b border-[rgba(255,255,255,0.07)] hover:bg-accent/80 bg-accent text-white glow-btn animate-ripple"
                   onClick={() => setOpen(false)}
                 >
                   Start Free Trial

--- a/components/marketing/EmailSignupForm.tsx
+++ b/components/marketing/EmailSignupForm.tsx
@@ -54,7 +54,7 @@ export default function EmailSignupForm({className=""}:{className?:string}) {
           <Button type="submit" className="w-full" disabled={status==='loading'}>
             {status==='loading' ? 'Submitting...' : 'Get Free Sample'}
           </Button>
-          <p className="text-xs text-gray-500 text-center">We respect your privacy. Unsubscribe anytime.</p>
+          <p className="text-xs text-text-secondary text-center">We respect your privacy. Unsubscribe anytime.</p>
           {status==='error' && <p className="text-red-600 text-sm text-center">Enter a valid email to receive the sample.</p>}
         </>
       )}

--- a/components/marketing/Testimonials.tsx
+++ b/components/marketing/Testimonials.tsx
@@ -45,7 +45,7 @@ export default function Testimonials({ className = '' }: { className?: string })
           >
             <p className="mb-4">&ldquo;{t.quote}&rdquo;</p>
             <p className="font-semibold">{t.name}</p>
-            <p className="text-sm text-gray-500">{t.role}</p>
+            <p className="text-sm text-text-secondary">{t.role}</p>
           </motion.div>
         ))}
       </div>

--- a/components/marketplace/MarketplaceClient.tsx
+++ b/components/marketplace/MarketplaceClient.tsx
@@ -420,7 +420,7 @@ export default function MarketplaceClient({
                                   ({product.reviews_count})
                                 </span>
                               </div>
-                              <span className="text-sm text-gray-500">
+                              <span className="text-sm text-text-secondary">
                                 {product.sales_count} sold
                               </span>
                             </div>
@@ -430,7 +430,7 @@ export default function MarketplaceClient({
                                   ${product.price}
                                 </span>
                                 {product.original_price && (
-                                  <span className="text-gray-500 line-through ml-2">
+                                  <span className="text-text-secondary line-through ml-2">
                                     ${product.original_price}
                                   </span>
                                 )}
@@ -520,7 +520,7 @@ export default function MarketplaceClient({
                           <h3 className="text-lg font-semibold group-hover:text-secondary-700 transition">
                             {product.name}
                           </h3>
-                          <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
+                          <span className="text-xs text-text-secondary bg-gray-100 px-2 py-1 rounded">
                             {
                               categories.find((c) => c.id === product.category)
                                 ?.name
@@ -533,7 +533,7 @@ export default function MarketplaceClient({
 
                         {/* Features */}
                         <div className="mb-4">
-                          <ul className="text-xs text-gray-500 space-y-1">
+                          <ul className="text-xs text-text-secondary space-y-1">
                             {(product.features
                               ? product.features.split(",")
                               : []
@@ -568,7 +568,7 @@ export default function MarketplaceClient({
                               {product.rating.toFixed(1)}
                             </span>
                           </div>
-                          <span className="text-xs text-gray-500">
+                          <span className="text-xs text-text-secondary">
                             {product.sales_count} sold
                           </span>
                         </div>
@@ -580,7 +580,7 @@ export default function MarketplaceClient({
                               ${product.price}
                             </span>
                             {product.original_price && (
-                              <span className="text-sm text-gray-500 line-through ml-2">
+                              <span className="text-sm text-text-secondary line-through ml-2">
                                 ${product.original_price}
                               </span>
                             )}

--- a/components/ui/AnimatedGradient.tsx
+++ b/components/ui/AnimatedGradient.tsx
@@ -6,7 +6,7 @@ export default function AnimatedGradient() {
     <motion.div
       className="absolute inset-0 -z-10 bg-gradient-animated"
       initial={{ opacity: 0.3 }}
-      animate={{ opacity: 0.6 }}
+      animate={{ opacity: 0.8 }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- use brand background and dark mode variables in globals
- reveal starfield in homepage hero and swap placeholder colors for brand teal and orange
- adjust AnimatedGradient opacity
- switch footer and navbar CTAs to brand accent
- change integration section color and replace generic greys with text-text-secondary

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68710d6ca4908323aa907d05fd4cbd00