### PR TITLE
Fix color consistency across UI

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -274,8 +274,8 @@ export default async function Dashboard() {
                 <p className="text-sm font-medium text-gray-600">AI Analyses</p>
                 <p className="text-2xl font-bold mt-1">{data.analyses.length}</p>
               </div>
-              <div className="w-12 h-12 bg-orange-100 rounded-full flex items-center justify-center">
-                <FileText className="w-6 h-6 text-orange-600" />
+              <div className="w-12 h-12 bg-warning/20 rounded-full flex items-center justify-center"> /* replaced orange with warning token */
+                <FileText className="w-6 h-6 text-warning" />
               </div>
             </div>
           </div>
@@ -573,7 +573,7 @@ export default async function Dashboard() {
 
         {/* Subscription Banner */}
         {data.profile?.subscription_tier === 'free' && (
-          <div className="mt-8 bg-gradient-to-r from-blue-600 to-blue-800 rounded-lg p-8 text-white">
+          <div className="mt-8 bg-gradient-to-r from-[var(--color-primary)] to-[color-mix(in_srgb,var(--color-primary)_80%,black)] rounded-lg p-8 text-white"> /* use primary token gradient */
             <div className="max-w-3xl">
               <h3 className="text-2xl font-bold mb-2">Upgrade to Pro</h3>
               <p className="text-secondary-700/20 mb-4">

--- a/app/get-started/page.tsx
+++ b/app/get-started/page.tsx
@@ -11,7 +11,7 @@ export const generateMetadata = () =>
 
 export default function GetStarted() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center p-8">
+    <div className="min-h-screen bg-gradient-to-b from-[var(--color-cloud-100)] to-white flex items-center justify-center p-8"> /* replaced blue-50 with cloud-100 token */
       <div className="max-w-xl text-center">
         <h1 className="text-4xl font-bold text-slate-900 mb-4">
           Start Your Free Trial

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,7 +39,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="manifest" href="/manifest.webmanifest" />
-        <meta name="theme-color" content="#0d1b2a" />
+        <meta name="theme-color" content="#0a192f" /> {/* navy-900 token */}
         <link
           rel="icon"
           href="https://via.placeholder.com/192"

--- a/app/og/image.tsx
+++ b/app/og/image.tsx
@@ -9,8 +9,8 @@ export async function GET() {
     <svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
       <defs>
         <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0%" stopColor="#0ea5e9" />
-          <stop offset="100%" stopColor="#3b82f6" />
+          <stop offset="0%" stopColor="var(--color-primary)" />
+          <stop offset="100%" stopColor="color-mix(in srgb,var(--color-primary) 80%, white)" /> /* replaced hex with primary token */
         </linearGradient>
       </defs>
       <rect width="1200" height="630" rx="40" fill="url(#g)" />

--- a/components/AIEstimator.tsx
+++ b/components/AIEstimator.tsx
@@ -236,7 +236,7 @@ export default function AIEstimator() {
                 value={address}
                 onChange={(e) => setAddress(e.target.value)}
                 placeholder="123 Main St, Denver, CO 80202"
-                className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-accent" /* replaced blue-500 with accent token */
               />
             </div>
 

--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -124,7 +124,7 @@ function OverviewTab({ stats }: { stats: DashboardStats }) {
         <StatCard title="Total Users" value={stats.totalUsers} icon={<Users className="w-6 h-6" />} color="blue" />
         <StatCard title="Total Orders" value={stats.totalOrders} icon={<Package className="w-6 h-6" />} color="green" />
         <StatCard title="Revenue" value={`$${stats.totalRevenue.toFixed(2)}`} icon={<DollarSign className="w-6 h-6" />} color="purple" />
-        <StatCard title="Active Products" value={stats.activeProducts} icon={<FileText className="w-6 h-6" />} color="orange" />
+        <StatCard title="Active Products" value={stats.activeProducts} icon={<FileText className="w-6 h-6" />} color="warning" /> /* replaced orange with warning token */
         <StatCard title="Pending Tickets" value={stats.pendingTickets} icon={<SettingsIcon className="w-6 h-6" />} color="red" />
       </div>
       <div className="bg-white rounded-lg shadow p-6">
@@ -135,7 +135,7 @@ function OverviewTab({ stats }: { stats: DashboardStats }) {
               <XAxis dataKey="month" />
               <YAxis />
               <Tooltip />
-              <Line type="monotone" dataKey="revenue" stroke="#3b82f6" />
+              <Line type="monotone" dataKey="revenue" stroke="var(--color-primary)" /> /* replaced hex with primary token */
             </LineChart>
           </ResponsiveContainer>
         ) : (
@@ -151,7 +151,7 @@ function StatCard({ title, value, icon, color }: { title: string; value: number 
     blue: 'bg-secondary-700/10 text-secondary-700',
     green: 'bg-accent-emerald/20 text-accent-emerald',
     purple: 'bg-purple-100 text-purple-600',
-    orange: 'bg-orange-100 text-orange-600',
+    warning: 'bg-warning/20 text-warning', /* replaced orange classes with warning token */
     red: 'bg-red-100 text-red-600'
   };
   return (
@@ -219,7 +219,7 @@ function OrdersTab() {
                 <td className="px-6 py-2">{order.products?.name || '—'}</td>
                 <td className="px-6 py-2">${order.amount.toFixed(2)}</td>
                 <td className="px-6 py-2">
-                  <span className={`px-2 py-1 text-xs rounded ${order.status === 'completed' ? 'bg-accent-emerald/20 text-accent-emerald' : 'bg-yellow-100 text-yellow-800'}`}>{order.status}</span>
+                  <span className={`px-2 py-1 text-xs rounded ${order.status === 'completed' ? 'bg-accent-emerald/20 text-accent-emerald' : 'bg-warning/20 text-warning'}`}>{order.status}</span> /* replaced yellow classes with warning token */
                 </td>
                 <td className="px-6 py-2">{new Date(order.created_at).toLocaleDateString()}</td>
               </tr>
@@ -543,7 +543,7 @@ function SettingsTab() {
         <p>Checking system health...</p>
       ) : health ? (
         <div>
-          <p className={`font-medium mb-4 ${health.status === 'healthy' ? 'text-accent-emerald' : health.status === 'degraded' ? 'text-yellow-600' : 'text-red-600'}`}>Overall Status: {health.status.charAt(0).toUpperCase() + health.status.slice(1)}</p>
+          <p className={`font-medium mb-4 ${health.status === 'healthy' ? 'text-accent-emerald' : health.status === 'degraded' ? 'text-warning' : 'text-red-600'}`}>Overall Status: {health.status.charAt(0).toUpperCase() + health.status.slice(1)}</p> /* replaced yellow-600 with warning token */
           <ul>
             <li>Database: <span className={health.services.database === 'healthy' ? 'text-accent-emerald' : 'text-red-600'}>{health.services.database}</span></li>
             <li>Storage: <span className={health.services.storage === 'healthy' ? 'text-accent-emerald' : 'text-red-600'}>{health.services.storage}</span></li>

--- a/components/EstimatorAR.tsx
+++ b/components/EstimatorAR.tsx
@@ -11,7 +11,14 @@ export default function EstimatorAR() {
           {/* Placeholder plane representing roof model */}
           <mesh rotation={[-0.5, 0.2, 0]}>
             <planeGeometry args={[3, 3]} />
-            <meshStandardMaterial color="orange" />
+          {(() => {
+            const c = typeof window !== 'undefined'
+              ? getComputedStyle(document.documentElement)
+                  .getPropertyValue('--color-warning')
+                  .trim() || '#ecc94b'
+              : '#ecc94b';
+            return <meshStandardMaterial color={c} />;
+          })()} /* uses warning token */
           </mesh>
           <ambientLight intensity={0.5} />
         </Suspense>

--- a/components/icons/AvatarPlaceholder.tsx
+++ b/components/icons/AvatarPlaceholder.tsx
@@ -13,9 +13,9 @@ export default function AvatarPlaceholder(
       aria-hidden="true"
       {...props}
     >
-      <circle cx="20" cy="20" r="20" fill="#e5e7eb" />
-      <circle cx="20" cy="15" r="6" fill="#9ca3af" />
-      <path d="M10 32c2-6 18-6 20 0" fill="#9ca3af" />
+      <circle cx="20" cy="20" r="20" fill="var(--color-cloud-100)" />
+      <circle cx="20" cy="15" r="6" fill="var(--color-slate-700)" />
+      <path d="M10 32c2-6 18-6 20 0" fill="var(--color-slate-700)" />
     </svg>
   );
 }

--- a/components/icons/BbbBadge.tsx
+++ b/components/icons/BbbBadge.tsx
@@ -10,7 +10,7 @@ export default function BbbBadge(props: React.SVGProps<SVGSVGElement>) {
       aria-label="BBB A+"
       {...props}
     >
-      <rect width="80" height="32" rx="4" fill="#0057b8" />
+      <rect width="80" height="32" rx="4" fill="var(--color-primary)" /> /* replaced hex with primary token */
       <text
         x="40"
         y="21"

--- a/components/icons/GafBadge.tsx
+++ b/components/icons/GafBadge.tsx
@@ -10,7 +10,7 @@ export default function GafBadge(props: React.SVGProps<SVGSVGElement>) {
       aria-label="GAF Master Elite"
       {...props}
     >
-      <rect width="80" height="32" rx="4" fill="#E31E26" />
+      <rect width="80" height="32" rx="4" fill="var(--color-danger)" /> /* replaced hex with danger token */
       <text
         x="40"
         y="21"

--- a/components/icons/GoogleReviews.tsx
+++ b/components/icons/GoogleReviews.tsx
@@ -13,8 +13,8 @@ export default function GoogleReviews(props: React.SVGProps<SVGSVGElement>) {
       aria-label="Google Reviews"
       {...props}
     >
-      <rect width="100" height="32" rx="4" fill="#fff" stroke="#e5e7eb" />
-      <g fill="#fbbc04" transform="translate(10 6) scale(0.8)">
+      <rect width="100" height="32" rx="4" fill="var(--color-white)" stroke="var(--color-cloud-100)" />
+      <g fill="var(--color-warning)" transform="translate(10 6) scale(0.8)">
         {Array.from({ length: 5 }).map((_, i) => (
           <g key={i} transform={`translate(${i * 20},0)`}>
             {star}

--- a/components/layout/MainLayout.tsx
+++ b/components/layout/MainLayout.tsx
@@ -10,10 +10,16 @@ export default function MainLayout({ children }: MainLayoutProps) {
     <>
       <style jsx global>{`
         body {
-          background: linear-gradient(-45deg, #121212, #0d1d31, #1E90FF, #005f73);
+          background: linear-gradient(
+            -45deg,
+            var(--color-navy-900),
+            var(--color-slate-700),
+            var(--color-primary),
+            var(--color-navy-900)
+          ); /* replaced hex gradient with design tokens */
           background-size: 400% 400%;
           animation: gradient 25s ease infinite;
-          color: #F0F0F0;
+          color: var(--color-cloud-100); /* replaced hex with cloud-100 token */
         }
         @keyframes gradient {
           0% { background-position: 0% 50%; }

--- a/components/layout/Starfield.tsx
+++ b/components/layout/Starfield.tsx
@@ -27,7 +27,7 @@ export default function Starfield() {
           left: 0;
           width: 6em;
           height: 2px;
-          color: #F0F0F0;
+          color: var(--color-cloud-100); /* replaced hex with cloud-100 token */
           background: linear-gradient(45deg, currentColor, transparent);
           border-radius: 50%;
           filter: drop-shadow(0 0 6px currentColor);

--- a/components/marketplace/MarketplaceClient.tsx
+++ b/components/marketplace/MarketplaceClient.tsx
@@ -218,7 +218,7 @@ export default function MarketplaceClient({
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6 }}
-        className="bg-gradient-to-r from-blue-600 to-blue-800/80 text-white py-12 backdrop-blur-lg rounded-2xl shadow-2xl"
+        className="bg-gradient-to-r from-[var(--color-primary)] to-[color-mix(in_srgb,var(--color-primary)_80%,black)] text-white py-12 backdrop-blur-lg rounded-2xl shadow-2xl" /* replaced blue gradient with primary token */
       >
         <div className="max-w-7xl mx-auto px-4">
           <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
@@ -321,7 +321,7 @@ export default function MarketplaceClient({
                 <select
                   value={sortBy}
                   onChange={(e) => setSortBy(e.target.value)}
-                  className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-accent" /* replaced blue-500 with accent token */
                 >
                   {sortOptions.map((option) => (
                     <option key={option.value} value={option.value}>
@@ -392,7 +392,7 @@ export default function MarketplaceClient({
                               </span>
                             )}
                             {product.sales_count > 500 && (
-                              <span className="absolute bottom-2 left-2 bg-orange-500 text-white text-xs px-2 py-1 rounded">
+                              <span className="absolute bottom-2 left-2 bg-warning text-white text-xs px-2 py-1 rounded"> /* replaced orange with warning token */
                                 BESTSELLER
                               </span>
                             )}
@@ -509,7 +509,7 @@ export default function MarketplaceClient({
                           </span>
                         )}
                         {product.sales_count > 500 && (
-                          <span className="absolute bottom-2 left-2 bg-orange-500 text-white text-xs px-2 py-1 rounded">
+                          <span className="absolute bottom-2 left-2 bg-warning text-white text-xs px-2 py-1 rounded"> /* replaced orange with warning token */
                             BESTSELLER
                           </span>
                         )}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -29,7 +29,7 @@ export default function Button({
 }: ButtonProps) {
   return (
     <motion.button
-      whileHover={{ scale: 1.05, boxShadow: "0 0 16px #5E5CE6" }}
+      whileHover={{ scale: 1.05, boxShadow: "0 0 16px var(--color-primary)" }} /* replaced hex with primary token */
       whileTap={{ scale: 0.95 }}
       className={clsx(base, variants[variant], sizes[size], className)}
       {...props}

--- a/components/ui/Hero3D.tsx
+++ b/components/ui/Hero3D.tsx
@@ -12,10 +12,16 @@ function SpinningShape() {
       ref.current.rotation.x += 0.005;
     }
   });
+  const color =
+    typeof window !== 'undefined'
+      ? getComputedStyle(document.documentElement)
+          .getPropertyValue('--color-primary')
+          .trim() || '#4299e1'
+      : '#4299e1';
   return (
     <mesh ref={ref}>
       <icosahedronGeometry args={[1, 0]} />
-      <meshStandardMaterial color="#5E5CE6" />
+      <meshStandardMaterial color={color} /> {/* uses primary token */}
     </mesh>
   );
 }

--- a/components/ui/ThemeProvider.tsx
+++ b/components/ui/ThemeProvider.tsx
@@ -12,7 +12,7 @@ interface ThemeCtx {
 const ThemeContext = createContext<ThemeCtx>({
   theme: 'dark',
   toggle: () => {},
-  accent: '#5276c5',
+  accent: '#4299e1', /* primary token */
   setAccent: () => {}
 });
 
@@ -23,7 +23,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       ? 'dark'
       : 'light'
   );
-  const [accent, setAccent] = useState('#5276c5');
+  const [accent, setAccent] = useState('#4299e1'); /* primary token */
 
   useEffect(() => {
     // Load persisted theme from localStorage if available

--- a/components/ui/protection-status.tsx
+++ b/components/ui/protection-status.tsx
@@ -18,7 +18,7 @@ export function ProtectionStatus({ status, message, details, className }: Protec
 
   const styles = {
     protected: 'bg-accent-emerald/5 text-accent-emerald border-accent-emerald/20',
-    warning: 'bg-orange-50 text-orange-900 border-orange-200',
+    warning: 'bg-warning/10 text-warning border-warning/50', /* replaced orange classes with warning token */
     danger: 'bg-red-50 text-red-900 border-red-200',
     calculating: 'bg-secondary-700/5 text-secondary-700 border-secondary-700/20'
   }

--- a/design-system/components/Button.tsx
+++ b/design-system/components/Button.tsx
@@ -29,7 +29,7 @@ export default function Button({
 }: ButtonProps) {
   return (
     <motion.button
-      whileHover={{ scale: 1.05, boxShadow: "0 0 16px #5E5CE6" }}
+      whileHover={{ scale: 1.05, boxShadow: "0 0 16px var(--color-primary)" }} /* replaced hex with primary token */
       whileTap={{ scale: 0.95 }}
       className={clsx(base, variants[variant], sizes[size], className)}
       {...props}


### PR DESCRIPTION
## Summary
- align meta theme color with navy-900 token
- use primary/warning design tokens across components
- swap legacy blue/orange classes for token-based styles
- ensure gradients and icons reference tokens
- replace hardcoded hex colors in 3D components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687181877040832380c9615cc4258f4c