### PR TITLE
Fix colors with design tokens

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -23,11 +23,11 @@ export default async function Account() {
   const orders = await getOrders();
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-bg">
       <div className="max-w-7xl mx-auto px-4 py-8">
         <h1 className="text-3xl font-bold mb-8">My Account</h1>
 
-        <div className="bg-white rounded-lg shadow p-6">
+        <div className="bg-bg-card rounded-lg shadow p-6">
           <h2 className="text-xl font-semibold mb-4">Order History</h2>
           {orders.length === 0 ? (
             <EmptyState message="No orders yet." />
@@ -38,9 +38,9 @@ export default async function Account() {
           )}
         </div>
 
-        <div className="mt-6 bg-white rounded-lg shadow p-6">
+        <div className="mt-6 bg-bg-card rounded-lg shadow p-6">
           <h2 className="text-xl font-semibold mb-4">Account Settings</h2>
-          <p className="text-gray-600">
+          <p className="text-text-secondary">
             Update your email or password from the profile menu. Contact support
             if you need any help managing your subscription.
           </p>

--- a/app/auth/setup-guide.tsx
+++ b/app/auth/setup-guide.tsx
@@ -90,21 +90,21 @@ export default async function BlogPost({ params }: { params: { slug: string } })
   }
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-bg">
       <article className="max-w-4xl mx-auto px-4 py-12">
         {/* Breadcrumb */}
         <nav className="mb-8 text-sm">
-          <Link href="/" className="text-text-secondary hover:text-gray-700">Home</Link>
-          <span className="mx-2 text-gray-400">/</span>
-          <Link href="/blog" className="text-text-secondary hover:text-gray-700">Blog</Link>
-          <span className="mx-2 text-gray-400">/</span>
-          <span className="text-gray-900">{post.category}</span>
+          <Link href="/" className="text-text-secondary hover:text-text-primary">Home</Link>
+          <span className="mx-2 text-text-secondary">/</span>
+          <Link href="/blog" className="text-text-secondary hover:text-text-primary">Blog</Link>
+          <span className="mx-2 text-text-secondary">/</span>
+          <span className="text-text-primary">{post.category}</span>
         </nav>
 
         {/* Article Header */}
         <header className="mb-8">
           <h1 className="text-4xl font-bold mb-4">{post.title}</h1>
-          <div className="flex items-center gap-4 text-gray-600">
+          <div className="flex items-center gap-4 text-text-secondary">
             <span className="font-medium">{post.author}</span>
             <span>•</span>
             <time>{new Date(post.published_at).toLocaleDateString()}</time>
@@ -120,9 +120,9 @@ export default async function BlogPost({ params }: { params: { slug: string } })
         />
 
         {/* CTA Section */}
-        <div className="mt-12 p-8 bg-gray-50 rounded-lg">
+        <div className="mt-12 p-8 bg-bg-card rounded-lg">
           <h3 className="text-2xl font-bold mb-4">Ready to Avoid These Costly Mistakes?</h3>
-          <p className="text-gray-600 mb-6">
+          <p className="text-text-secondary mb-6">
             Download our comprehensive Quote-to-Close Kit and take control of your next roofing project.
           </p>
           <Link
@@ -134,11 +134,11 @@ export default async function BlogPost({ params }: { params: { slug: string } })
         </div>
 
         {/* Author Bio */}
-        <div className="mt-12 p-6 bg-gray-50 rounded-lg flex gap-4">
-          <div className="w-20 h-20 bg-gray-300 rounded-full flex-shrink-0"></div>
+        <div className="mt-12 p-6 bg-bg-card rounded-lg flex gap-4">
+          <div className="w-20 h-20 bg-secondary/20 rounded-full flex-shrink-0"></div>
           <div>
             <h4 className="font-semibold mb-1">{post.author}</h4>
-            <p className="text-gray-600 text-sm mb-2">
+            <p className="text-text-secondary text-sm mb-2">
               Founder of MyRoofGenius with 15+ years in commercial roofing operations and technology implementation.
             </p>
             <Link href="/about" className="text-secondary-700 text-sm hover:underline">

--- a/app/fieldapps/FieldAppsClient.tsx
+++ b/app/fieldapps/FieldAppsClient.tsx
@@ -127,11 +127,11 @@ export default function FieldAppsClient() {
       </div>
       {showQueue && (
         <div
-          className="fixed inset-0 bg-black/50 flex items-center justify-center"
+          className="fixed inset-0 bg-bg/80 flex items-center justify-center"
           role="dialog"
           aria-modal="true"
         >
-          <div className="bg-white p-6 rounded-lg max-w-sm w-full">
+          <div className="bg-bg-card p-6 rounded-lg max-w-sm w-full">
             <h2 className="text-xl font-bold mb-4">Offline Actions</h2>
             {queue.length === 0 ? (
               <p className="text-sm">No actions queued.</p>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -47,12 +47,12 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-bg p-4">
       <div className="w-full max-w-md space-y-6">
         <h1 className="text-3xl font-bold text-center">Create account</h1>
         <Form onSubmit={handleSignup} className="space-y-4">
           {error && (
-            <p className="text-red-600 text-sm" id="signup-error">
+            <p className="text-danger text-sm" id="signup-error">
               {error}
             </p>
           )}

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -10,8 +10,8 @@ export default function SuccessPage() {
     triggerConfetti();
   }, [triggerConfetti]);
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="max-w-md w-full space-y-8 p-8 bg-white rounded-lg shadow">
+    <div className="min-h-screen flex items-center justify-center bg-bg">
+      <div className="max-w-md w-full space-y-8 p-8 bg-bg-card rounded-lg shadow">
         <UpgradeBanner />
         <div className="text-center">
           <div className="mx-auto h-12 w-12 text-accent-emerald">
@@ -19,10 +19,10 @@ export default function SuccessPage() {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
             </svg>
           </div>
-          <h2 className="mt-6 text-3xl font-extrabold text-gray-900">
+          <h2 className="mt-6 text-3xl font-extrabold text-text-primary">
             Payment Successful!
           </h2>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm text-text-secondary">
             Thank you for your purchase. You&apos;ll receive a confirmation email shortly.
           </p>
         </div>
@@ -36,7 +36,7 @@ export default function SuccessPage() {
           </Link>
           <Link
             href="/products"
-            className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
+            className="w-full flex justify-center py-2 px-4 border border-secondary/30 rounded-md shadow-sm text-sm font-medium text-text-secondary bg-bg-card hover:bg-bg"
           >
             Browse More Products
           </Link>

--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -81,8 +81,8 @@ export default function AdminDashboard() {
   if (loading) return <div className="p-4">Loading...</div>;
   if (!isAdmin) return <div className="p-4">Access Denied</div>;
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="bg-white shadow">
+    <div className="min-h-screen bg-bg">
+      <div className="bg-bg-card shadow">
         <div className="max-w-7xl mx-auto px-4 py-6">
           <h1 className="text-3xl font-bold">{messages.adminDashboard}</h1>
         </div>
@@ -95,7 +95,7 @@ export default function AdminDashboard() {
               key={tab}
               onClick={() => setActiveTab(tab)}
               className={`px-4 py-2 font-medium capitalize ${
-                activeTab === tab ? 'text-secondary-700 border-b-2 border-secondary-700' : 'text-gray-600 hover:text-gray-900'
+                activeTab === tab ? 'text-secondary-700 border-b-2 border-secondary-700' : 'text-text-secondary hover:text-text-primary'
               }`}
             >
               {tab}
@@ -158,7 +158,7 @@ function StatCard({ title, value, icon, color }: { title: string; value: number 
     <div className="bg-white rounded-lg shadow p-6">
       <div className="flex items-center justify-between">
         <div>
-          <p className="text-sm font-medium text-gray-600">{title}</p>
+          <p className="text-sm font-medium text-text-secondary">{title}</p>
           <p className="text-2xl font-bold mt-1">{value}</p>
         </div>
         <div className={`w-12 h-12 rounded-full flex items-center justify-center ${colorClasses[color]}`}>{icon}</div>
@@ -211,7 +211,7 @@ function OrdersTab() {
               <th className="px-6 py-3">Date</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-secondary/20">
             {orders.map(order => (
               <tr key={order.id}>
                 <td className="px-6 py-2">{order.id.slice(0, 8)}...</td>
@@ -275,7 +275,7 @@ function ProductsTab() {
               <th className="px-6 py-3">Actions</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-secondary/20">
             {products.map(product => (
               <tr key={product.id}>
                 <td className="px-6 py-3">
@@ -290,7 +290,7 @@ function ProductsTab() {
                 <td className="px-6 py-3">{product.category}</td>
                 <td className="px-6 py-3">${product.price.toFixed(2)}</td>
                 <td className="px-6 py-3">
-                  <span className={`px-2 py-1 text-xs rounded ${product.is_active ? 'bg-accent-emerald/20 text-accent-emerald' : 'bg-gray-100 text-gray-800'}`}>{product.is_active ? 'Active' : 'Inactive'}</span>
+                  <span className={`px-2 py-1 text-xs rounded ${product.is_active ? 'bg-accent-emerald/20 text-accent-emerald' : 'bg-secondary/20 text-text-secondary'}`}>{product.is_active ? 'Active' : 'Inactive'}</span>
                 </td>
                 <td className="px-6 py-3">
                   <button className="text-secondary-700 hover:underline mr-3">Edit</button>
@@ -423,7 +423,7 @@ function UsersTab() {
               <th className="px-4 py-3">Actions</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-secondary/20">
             {users.map(user => (
               <tr key={user.user_id}>
                 <td className="px-4 py-2">{user.full_name || '—'}</td>
@@ -501,7 +501,7 @@ function AITab() {
               <th className="px-4 py-3">Message</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-secondary/20">
             {logs.map((log: any) => (
               <tr key={log.id}>
                 <td className="px-4 py-2">{new Date(log.created_at).toLocaleString()}</td>

--- a/components/Dashboard3D.tsx
+++ b/components/Dashboard3D.tsx
@@ -8,7 +8,7 @@ import { PresenceProvider, PresenceAvatars } from './ui';
 export default function Dashboard3D() {
   return (
     <PresenceProvider room="dashboard">
-    <div className="relative h-64 w-full bg-gray-900 text-white rounded-xl">
+    <div className="relative h-64 w-full bg-[var(--color-navy-900)] text-white rounded-xl">
       <PresenceAvatars />
       <Canvas camera={{ position: [3, 3, 3] }}>
         <Suspense fallback={null}>
@@ -16,12 +16,28 @@ export default function Dashboard3D() {
             {/* base */}
             <mesh position={[0, 0.5, 0]}>
               <boxGeometry args={[2, 1, 2]} />
-              <meshStandardMaterial color="#6b7280" />
+              <meshStandardMaterial
+                color={
+                  typeof window !== 'undefined'
+                    ? getComputedStyle(document.documentElement)
+                        .getPropertyValue('--color-slate-700')
+                        .trim() || '#6b7280'
+                    : '#6b7280'
+                }
+              />
             </mesh>
             {/* roof */}
             <mesh rotation={[0, 0, Math.PI / 4]} position={[0, 1.2, 0]}>
               <coneGeometry args={[1.6, 1, 4]} />
-              <meshStandardMaterial color="#9ca3af" />
+              <meshStandardMaterial
+                color={
+                  typeof window !== 'undefined'
+                    ? getComputedStyle(document.documentElement)
+                        .getPropertyValue('--color-text-secondary')
+                        .trim() || '#9ca3af'
+                    : '#9ca3af'
+                }
+              />
             </mesh>
           </group>
           <ambientLight intensity={0.5} />

--- a/components/EstimatorAR.tsx
+++ b/components/EstimatorAR.tsx
@@ -5,7 +5,7 @@ import { Suspense } from 'react';
 
 export default function EstimatorAR() {
   return (
-    <div className="h-64 w-full bg-gray-900 text-white rounded-xl mt-4">
+    <div className="h-64 w-full bg-[var(--color-navy-900)] text-white rounded-xl mt-4">
       <Canvas>
         <Suspense fallback={null}>
           {/* Placeholder plane representing roof model */}

--- a/components/OfflineIndicator.tsx
+++ b/components/OfflineIndicator.tsx
@@ -12,13 +12,13 @@ export default function OfflineIndicator({
 }: OfflineIndicatorProps) {
   return (
     <div
-      className="fixed top-4 right-4 flex items-center gap-2 text-sm"
+      className="fixed top-4 right-4 flex items-center gap-2 text-sm z-50"
       aria-live="polite"
     >
       {!online ? (
         <>
-          <CloudOff className="w-5 h-5 text-red-600" aria-hidden="true" />
-          <span className="text-red-600">Offline</span>
+          <CloudOff className="w-5 h-5 text-danger" aria-hidden="true" />
+          <span className="text-danger">Offline</span>
         </>
       ) : syncing ? (
         <>

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -32,7 +32,7 @@ export default function Card({
       className={clsx(
         "rounded-2xl p-6 min-h-[48px]",
         glass
-          ? "glass-card backdrop-blur-lg bg-white/30 shadow-2xl"
+          ? "glass-card backdrop-blur-lg bg-[var(--color-white)/0.3] shadow-2xl"
           : "bg-bg-card",
         className,
       )}

--- a/components/ui/ThemeProvider.tsx
+++ b/components/ui/ThemeProvider.tsx
@@ -12,7 +12,12 @@ interface ThemeCtx {
 const ThemeContext = createContext<ThemeCtx>({
   theme: 'dark',
   toggle: () => {},
-  accent: '#4299e1', /* primary token */
+  accent:
+    typeof window !== 'undefined'
+      ? getComputedStyle(document.documentElement)
+          .getPropertyValue('--color-primary')
+          .trim()
+      : '#4299e1',
   setAccent: () => {}
 });
 
@@ -23,7 +28,13 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       ? 'dark'
       : 'light'
   );
-  const [accent, setAccent] = useState('#4299e1'); /* primary token */
+  const [accent, setAccent] = useState(() =>
+    typeof window !== 'undefined'
+      ? getComputedStyle(document.documentElement)
+          .getPropertyValue('--color-primary')
+          .trim() || '#4299e1'
+      : '#4299e1'
+  );
 
   useEffect(() => {
     // Load persisted theme from localStorage if available

--- a/design-system/components/Input.tsx
+++ b/design-system/components/Input.tsx
@@ -37,7 +37,7 @@ export const Input = React.forwardRef<
         aria-invalid={!!error}
         aria-describedby={errorId}
         className={clsx(
-          "block w-full rounded-md border border-gray-300 px-3 py-2 min-h-[48px] focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent disabled:bg-gray-100",
+          "block w-full rounded-md border border-secondary/40 px-3 py-2 min-h-[48px] focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent disabled:bg-bg-card",
           error &&
             "border-danger text-danger focus:ring-danger focus:border-danger",
           className,
@@ -69,7 +69,7 @@ export const Select = React.forwardRef<
         aria-invalid={!!error}
         aria-describedby={errorId}
         className={clsx(
-          "block w-full rounded-md border border-gray-300 px-3 py-2 min-h-[48px] focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent disabled:bg-gray-100",
+          "block w-full rounded-md border border-secondary/40 px-3 py-2 min-h-[48px] focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent disabled:bg-bg-card",
           error &&
             "border-danger text-danger focus:ring-danger focus:border-danger",
           className,
@@ -103,7 +103,7 @@ export const Textarea = React.forwardRef<
         aria-invalid={!!error}
         aria-describedby={errorId}
         className={clsx(
-          "block w-full rounded-md border border-gray-300 px-3 py-2 min-h-[48px] focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent disabled:bg-gray-100",
+          "block w-full rounded-md border border-secondary/40 px-3 py-2 min-h-[48px] focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent disabled:bg-bg-card",
           error &&
             "border-danger text-danger focus:ring-danger focus:border-danger",
           className,
@@ -136,7 +136,7 @@ export const Checkbox = React.forwardRef<
           aria-invalid={!!error}
           aria-describedby={errorId}
           className={clsx(
-            "rounded border-gray-300 text-accent focus:ring-accent disabled:bg-gray-100",
+            "rounded border-secondary/40 text-accent focus:ring-accent disabled:bg-bg-card",
             error && "border-danger text-danger focus:ring-danger",
             className,
           )}
@@ -172,7 +172,7 @@ export const Radio = React.forwardRef<
           aria-invalid={!!error}
           aria-describedby={errorId}
           className={clsx(
-            "border-gray-300 text-accent focus:ring-accent disabled:bg-gray-100",
+            "border-secondary/40 text-accent focus:ring-accent disabled:bg-bg-card",
             error && "border-danger text-danger focus:ring-danger",
             className,
           )}

--- a/design-system/components/OfflineIndicator.tsx
+++ b/design-system/components/OfflineIndicator.tsx
@@ -12,13 +12,13 @@ export default function OfflineIndicator({
 }: OfflineIndicatorProps) {
   return (
     <div
-      className="fixed top-4 right-4 flex items-center gap-2 text-sm"
+      className="fixed top-4 right-4 flex items-center gap-2 text-sm z-50"
       aria-live="polite"
     >
       {!online ? (
         <>
-          <CloudOff className="w-5 h-5 text-red-600" aria-hidden="true" />
-          <span className="text-red-600">Offline</span>
+          <CloudOff className="w-5 h-5 text-danger" aria-hidden="true" />
+          <span className="text-danger">Offline</span>
         </>
       ) : syncing ? (
         <>

--- a/design-system/components/TrustBar.tsx
+++ b/design-system/components/TrustBar.tsx
@@ -6,7 +6,7 @@ import SslLock from "./icons/SslLock";
 
 export default function TrustBar() {
   return (
-    <div className="bg-bg py-4 border-y border-gray-200">
+    <div className="bg-bg py-4 border-y border-secondary/20">
       <div className="max-w-6xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 px-4">
         <div className="flex items-center space-x-4">
           <GafBadge className="h-8" />


### PR DESCRIPTION
## Summary
- replace remaining gray color classes with tokens
- pull primary accent color from CSS variables in ThemeProvider
- fix 3D components and overlays to use tokens
- adjust various pages and admin dashboard colors

## Testing
- `npm test`
- `npm run test:visual-only`

------
https://chatgpt.com/codex/tasks/task_e_6871cd01904083238c175277d6f7d111