### PR TITLE
UI polish updates for hero and surfaces

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -94,7 +94,7 @@ export default function HomeClient() {
               initial={{ opacity: 0, y: 40 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ type: "spring", stiffness: 80 }}
-              className="text-5xl md:text-6xl font-bold text-white mb-6 leading-tight"
+              className="text-4xl sm:text-5xl md:text-6xl font-bold text-white mb-6 leading-tight"
             >
               <HeroHeadline
                 texts={["Protect every project.", "Grow every margin."]}

--- a/app/globals.css
+++ b/app/globals.css
@@ -142,9 +142,14 @@
 }
 
 .hero-headline {
-  min-height: 3.5rem;
   position: relative;
   overflow: hidden;
+  min-height: 4.5rem;
+}
+@media (min-width: 640px) {
+  .hero-headline {
+    min-height: 3.5rem;
+  }
 }
 .hero-headline span {
   position: absolute;

--- a/components/Dashboard3D.tsx
+++ b/components/Dashboard3D.tsx
@@ -2,13 +2,19 @@
 /* eslint-disable react/no-unknown-property */
 import { Canvas } from '@react-three/fiber';
 import { Suspense } from 'react';
+import { motion } from 'framer-motion';
 import { OrbitControls } from '@react-three/drei';
 import { PresenceProvider, PresenceAvatars } from './ui';
 
 export default function Dashboard3D() {
   return (
     <PresenceProvider room="dashboard">
-    <div className="relative h-64 w-full bg-[var(--color-navy-900)] text-white rounded-xl">
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      whileInView={{ opacity: 1, scale: 1 }}
+      viewport={{ once: true }}
+      className="relative h-64 w-full bg-[var(--color-navy-900)] text-white rounded-xl"
+    >
       <PresenceAvatars />
       <Canvas camera={{ position: [3, 3, 3] }}>
         <Suspense fallback={null}>
@@ -45,7 +51,7 @@ export default function Dashboard3D() {
           <OrbitControls enablePan={false} />
         </Suspense>
       </Canvas>
-    </div>
+    </motion.div>
     </PresenceProvider>
   );
 }

--- a/components/EstimatorAR.tsx
+++ b/components/EstimatorAR.tsx
@@ -2,10 +2,16 @@
 /* eslint-disable react/no-unknown-property */
 import { Canvas } from '@react-three/fiber';
 import { Suspense } from 'react';
+import { motion } from 'framer-motion';
 
 export default function EstimatorAR() {
   return (
-    <div className="h-64 w-full bg-[var(--color-navy-900)] text-white rounded-xl mt-4">
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      whileInView={{ opacity: 1, scale: 1 }}
+      viewport={{ once: true }}
+      className="h-64 w-full bg-[var(--color-navy-900)] text-white rounded-xl mt-4"
+    >
       <Canvas>
         <Suspense fallback={null}>
           {/* Placeholder plane representing roof model */}
@@ -23,6 +29,6 @@ export default function EstimatorAR() {
           <ambientLight intensity={0.5} />
         </Suspense>
       </Canvas>
-    </div>
+    </motion.div>
   );
 }

--- a/components/TrustBar.tsx
+++ b/components/TrustBar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { motion } from "framer-motion";
 import GafBadge from "./icons/GafBadge";
 import BbbBadge from "./icons/BbbBadge";
 import GoogleReviews from "./icons/GoogleReviews";
@@ -6,7 +7,12 @@ import SslLock from "./icons/SslLock";
 
 export default function TrustBar() {
   return (
-    <div className="bg-bg py-4 border-y border-gray-200">
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.6 }}
+      className="bg-bg py-4 border-y border-gray-200"
+    >
       <div className="max-w-6xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 px-4">
         <div className="flex items-center space-x-4">
           <GafBadge className="h-8" />
@@ -18,6 +24,6 @@ export default function TrustBar() {
           Your photos are encrypted (AES-256) and deleted after analysis.
         </p>
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/components/marketing/EmailSignupForm.tsx
+++ b/components/marketing/EmailSignupForm.tsx
@@ -43,7 +43,7 @@ export default function EmailSignupForm({
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       className={clsx(
-        "space-y-4 glass backdrop-blur-lg bg-white/30 rounded-2xl shadow-2xl p-6",
+        "space-y-4 glass backdrop-blur-lg bg-cloud-100/30 dark:bg-slate-700/30 rounded-2xl shadow-2xl p-6",
         className,
       )}
     >

--- a/components/marketing/FeaturedToolsCarousel.tsx
+++ b/components/marketing/FeaturedToolsCarousel.tsx
@@ -79,7 +79,7 @@ export default function FeaturedToolsCarousel() {
             }}
             onMouseLeave={() => setTilt({ x: 0, y: 0 })}
             style={{ rotateX: tilt.x, rotateY: tilt.y }}
-            className="absolute inset-0 glass-card backdrop-blur-lg bg-white/30 rounded-2xl shadow-2xl"
+            className="absolute inset-0 glass-card backdrop-blur-lg bg-cloud-100/30 dark:bg-slate-700/30 rounded-2xl shadow-2xl"
           >
             <Image
               src={tools[index].image}

--- a/components/marketing/Testimonials.tsx
+++ b/components/marketing/Testimonials.tsx
@@ -41,7 +41,7 @@ export default function Testimonials({ className = '' }: { className?: string })
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: i * 0.2 }}
-            className="bg-white rounded-xl shadow p-6"
+            className="bg-cloud-100 dark:bg-slate-700 rounded-xl shadow p-6"
           >
             <p className="mb-4">&ldquo;{t.quote}&rdquo;</p>
             <p className="font-semibold">{t.name}</p>

--- a/components/ui/Hero3D.tsx
+++ b/components/ui/Hero3D.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable react/no-unknown-property */
 import { Canvas, useFrame } from '@react-three/fiber';
 import { useRef } from 'react';
+import { motion } from 'framer-motion';
 import * as THREE from 'three';
 
 function SpinningShape() {
@@ -28,12 +29,17 @@ function SpinningShape() {
 
 export default function Hero3D() {
   return (
-    <div className="h-64 w-full">
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      whileInView={{ opacity: 1, scale: 1 }}
+      viewport={{ once: true }}
+      className="h-64 w-full bg-slate-700/20 rounded-xl"
+    >
       <Canvas camera={{ position: [0, 0, 4] }}>
         <ambientLight intensity={0.5} />
         <pointLight position={[5, 5, 5]} />
         <SpinningShape />
       </Canvas>
-    </div>
+    </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- tweak hero headline responsive sizing
- adjust dynamic hero headline container height
- use motion fade on TrustBar
- add entrance animation to 3D components
- make dark-theme surface colors consistent

## Testing
- `npm run lint` *(fails: Comments inside children section of tag should be placed inside braces)*
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6871e53396008323939717148a51f177