### PR TITLE
Interactive hero background with new AI chat widget

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -7,6 +7,7 @@ import {
   AnimatedGradient,
   HeroHeadline,
   Skeleton,
+  BackgroundCanvas,
 } from "../components/ui";
 import { Suspense } from "react";
 import dynamicImport from "next/dynamic";
@@ -79,6 +80,7 @@ export default function HomeClient() {
         className="relative overflow-hidden bg-black/20 py-24 backdrop-blur-lg rounded-2xl shadow-2xl"
       >
         <AnimatedGradient />
+        <BackgroundCanvas />
         <div className="absolute top-6 right-6">
           <ActiveUsersBadge />
         </div>
@@ -94,11 +96,11 @@ export default function HomeClient() {
               initial={{ opacity: 0, y: 40 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ type: "spring", stiffness: 80 }}
-              className="text-4xl sm:text-5xl md:text-6xl font-bold text-white mb-6 leading-tight"
+              className="text-white font-extrabold text-4xl sm:text-5xl md:text-6xl mb-6 leading-tight"
             >
               <HeroHeadline
                 texts={["Protect every project.", "Grow every margin."]}
-                className="text-accent"
+                className="text-accent whitespace-pre-line"
               />
             </motion.h1>
             <ul className="text-slate-300 mb-8 space-y-2">

--- a/app/estimator/page.tsx
+++ b/app/estimator/page.tsx
@@ -1,6 +1,6 @@
 import dynamicImport from "next/dynamic";
 import { estimatorEnabled } from "../lib/features";
-import CopilotQuickButton from "../../components/CopilotQuickButton";
+import { PagePrompt } from "../../components/ui";
 
 const Estimator = dynamicImport(
   () => import("../../components/SimpleEstimator"),
@@ -18,9 +18,11 @@ export default function EstimatorPage() {
     );
   }
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-8 space-y-4">
-      <Estimator />
-      <CopilotQuickButton prompt="Estimate roofing materials" />
-    </div>
+    <>
+      <PagePrompt prompt="Estimate roofing materials" />
+      <div className="min-h-screen flex flex-col items-center justify-center p-8 space-y-4">
+        <Estimator />
+      </div>
+    </>
   );
 }

--- a/app/field-apps/page.tsx
+++ b/app/field-apps/page.tsx
@@ -28,7 +28,7 @@ export default function FieldAppsPage() {
         </div>
 
         {/* What This Protects */}
-        <div className="bg-white rounded-2xl shadow-lg border border-slate-200 p-8 mb-12">
+        <div className="bg-cloud-100 dark:bg-slate-700 rounded-2xl shadow-lg border border-slate-200 dark:border-slate-600 p-8 mb-12">
           <h2 className="text-2xl font-semibold mb-8 text-center">What Our Field Apps Protect</h2>
           <div className="grid md:grid-cols-3 gap-8">
             <div className="text-center">

--- a/app/globals.css
+++ b/app/globals.css
@@ -153,6 +153,8 @@
 }
 .hero-headline span {
   position: absolute;
+  width: 100%;
+  white-space: pre-line;
   opacity: 0;
   transition: opacity 0.5s ease-in-out;
 }

--- a/app/tools/ToolsClient.tsx
+++ b/app/tools/ToolsClient.tsx
@@ -115,7 +115,7 @@ function ToolCard({ name, description, features, link, icon, saveTime }) {
       initial={{ opacity: 0, y: 40 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
-      className="bg-white/30 backdrop-blur-lg shadow-xl border border-white/20 p-6"
+      className="bg-cloud-100/30 dark:bg-slate-700/30 backdrop-blur-lg shadow-xl border border-white/20 p-6"
     >
       <div className="flex items-start justify-between mb-4">
         <div className="w-12 h-12 bg-secondary-700/10 rounded-lg flex items-center justify-center">
@@ -150,7 +150,7 @@ function ToolCard({ name, description, features, link, icon, saveTime }) {
 
 function IntegrationBadge({ name }) {
   return (
-    <span className="inline-flex items-center px-4 py-2 bg-white rounded-lg text-slate-700 font-medium">
+    <span className="inline-flex items-center px-4 py-2 bg-cloud-100 dark:bg-slate-700 rounded-lg text-slate-700 dark:text-slate-200 font-medium">
       <span className="w-2 h-2 bg-accent-emerald/50 rounded-full mr-2"></span>
       {name}
     </span>

--- a/app/tools/cash-flow/page.tsx
+++ b/app/tools/cash-flow/page.tsx
@@ -3,13 +3,15 @@ import Link from "next/link";
 import Image from "next/image";
 import { useState } from "react";
 import ToolDemoModal from "../../../components/marketing/ToolDemoModal";
-import CopilotQuickButton from "../../../components/CopilotQuickButton";
+import { PagePrompt } from "../../../components/ui";
 
 export default function CashFlow() {
   const [showDemo, setShowDemo] = useState(false);
   return (
+    <>
+      <PagePrompt prompt="Tips for cash flow forecasting" />
     <div className="min-h-screen bg-gray-50 p-8 flex items-center justify-center">
-      <div className="max-w-2xl bg-white rounded-xl shadow p-8 text-center">
+      <div className="max-w-2xl bg-cloud-100 dark:bg-slate-700 rounded-xl shadow-lg p-8 text-center">
         <Image
           src="https://images.unsplash.com/photo-1556740723-198c99fd4c79?w=800&h=450&fit=crop"
           alt="Cash flow forecaster screenshot"
@@ -39,7 +41,6 @@ export default function CashFlow() {
           >
             Create Free Account
           </Link>
-          <CopilotQuickButton prompt="Tips for cash flow forecasting" />
         </div>
         <ToolDemoModal
           open={showDemo}
@@ -48,5 +49,6 @@ export default function CashFlow() {
         />
       </div>
     </div>
+    </>
   );
 }

--- a/app/tools/change-orders/page.tsx
+++ b/app/tools/change-orders/page.tsx
@@ -3,13 +3,15 @@ import Link from "next/link";
 import Image from "next/image";
 import { useState } from "react";
 import ToolDemoModal from "../../../components/marketing/ToolDemoModal";
-import CopilotQuickButton from "../../../components/CopilotQuickButton";
+import { PagePrompt } from "../../../components/ui";
 
 export default function ChangeOrders() {
   const [showDemo, setShowDemo] = useState(false);
   return (
+    <>
+      <PagePrompt prompt="How to manage change orders" />
     <div className="min-h-screen bg-gray-50 p-8 flex items-center justify-center">
-      <div className="max-w-2xl bg-white rounded-xl shadow p-8 text-center">
+      <div className="max-w-2xl bg-cloud-100 dark:bg-slate-700 rounded-xl shadow-lg p-8 text-center">
         <Image
           src="https://images.unsplash.com/photo-1581092613290-7e876675c352?w=800&h=450&fit=crop"
           alt="Change order calculator screenshot"
@@ -39,7 +41,6 @@ export default function ChangeOrders() {
           >
             Create Free Account
           </Link>
-          <CopilotQuickButton prompt="How to manage change orders" />
         </div>
         <ToolDemoModal
           open={showDemo}
@@ -48,5 +49,6 @@ export default function ChangeOrders() {
         />
       </div>
     </div>
+    </>
   );
 }

--- a/app/tools/labor-estimator/page.tsx
+++ b/app/tools/labor-estimator/page.tsx
@@ -3,13 +3,15 @@ import Link from "next/link";
 import Image from "next/image";
 import { useState } from "react";
 import ToolDemoModal from "../../../components/marketing/ToolDemoModal";
-import CopilotQuickButton from "../../../components/CopilotQuickButton";
+import { PagePrompt } from "../../../components/ui";
 
 export default function LaborEstimator() {
   const [showDemo, setShowDemo] = useState(false);
   return (
+    <>
+      <PagePrompt prompt="Help me estimate labor hours" />
     <div className="min-h-screen bg-gray-50 p-8 flex items-center justify-center">
-      <div className="max-w-2xl bg-white rounded-xl shadow p-8 text-center">
+      <div className="max-w-2xl bg-cloud-100 dark:bg-slate-700 rounded-xl shadow-lg p-8 text-center">
         <Image
           src="https://images.unsplash.com/photo-1596075781084-bd077eef0722?w=800&h=450&fit=crop"
           alt="Labor estimator screenshot"
@@ -39,7 +41,6 @@ export default function LaborEstimator() {
           >
             Create Free Account
           </Link>
-          <CopilotQuickButton prompt="Help me estimate labor hours" />
         </div>
         <ToolDemoModal
           open={showDemo}
@@ -48,5 +49,6 @@ export default function LaborEstimator() {
         />
       </div>
     </div>
+    </>
   );
 }

--- a/app/tools/material-calculator/page.tsx
+++ b/app/tools/material-calculator/page.tsx
@@ -3,13 +3,15 @@ import Link from "next/link";
 import Image from "next/image";
 import { useState } from "react";
 import ToolDemoModal from "../../../components/marketing/ToolDemoModal";
-import CopilotQuickButton from "../../../components/CopilotQuickButton";
+import { PagePrompt } from "../../../components/ui";
 
 export default function MaterialCalculator() {
   const [showDemo, setShowDemo] = useState(false);
   return (
+    <>
+      <PagePrompt prompt="Material calculation help" />
     <div className="min-h-screen bg-gray-50 p-8 flex items-center justify-center">
-      <div className="max-w-2xl bg-white rounded-xl shadow p-8 text-center">
+      <div className="max-w-2xl bg-cloud-100 dark:bg-slate-700 rounded-xl shadow-lg p-8 text-center">
         <Image
           src="https://images.unsplash.com/photo-1581093458791-9c2ca846fb74?w=800&h=450&fit=crop"
           alt="Material calculator screenshot"
@@ -40,7 +42,6 @@ export default function MaterialCalculator() {
           >
             Create Free Account
           </Link>
-          <CopilotQuickButton prompt="Material calculation help" />
         </div>
         <ToolDemoModal
           open={showDemo}
@@ -49,5 +50,6 @@ export default function MaterialCalculator() {
         />
       </div>
     </div>
+    </>
   );
 }

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { useState, useEffect } from 'react';
+import CopilotPanel from './CopilotPanel';
+import { MessageCircle } from 'lucide-react';
+
+export default function ChatWidget() {
+  const [open, setOpen] = useState(false);
+  const [engine, setEngine] = useState('GPT');
+  const [prompt, setPrompt] = useState('Need help analyzing?');
+  useEffect(() => {
+    const saved = localStorage.getItem('aiEngine');
+    if (saved) setEngine(saved);
+    const ins = localStorage.getItem('aiInstructions');
+    if (ins) setPrompt(ins);
+    const pagePrompt = document.body.dataset.pagePrompt;
+    if (pagePrompt) setPrompt(pagePrompt);
+  }, []);
+  useEffect(() => {
+    localStorage.setItem('aiEngine', engine);
+  }, [engine]);
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="fixed bottom-6 right-6 rounded-full w-14 h-14 bg-accent text-white flex items-center justify-center shadow-lg hover:scale-110 transition"
+      >
+        <MessageCircle className="w-6 h-6" />
+        <span className="sr-only">Ask AI</span>
+      </button>
+      {open && (
+        <div className="fixed bottom-24 right-6 bg-bg-card rounded-lg shadow-md p-2 text-sm flex items-center gap-2">
+          <span>{engine}</span>
+          <select
+            value={engine}
+            onChange={(e) => setEngine(e.target.value)}
+            className="bg-transparent focus:outline-none"
+          >
+            <option value="Claude">Claude</option>
+            <option value="Gemini">Gemini</option>
+            <option value="GPT">GPT</option>
+          </select>
+        </div>
+      )}
+      <CopilotPanel open={open} onClose={() => setOpen(false)} initialPrompt={prompt} />
+    </>
+  );
+}

--- a/components/Dashboard3D.tsx
+++ b/components/Dashboard3D.tsx
@@ -13,7 +13,7 @@ export default function Dashboard3D() {
       initial={{ opacity: 0, scale: 0.95 }}
       whileInView={{ opacity: 1, scale: 1 }}
       viewport={{ once: true }}
-      className="relative h-64 w-full bg-[var(--color-navy-900)] text-white rounded-xl"
+      className="relative h-64 w-full bg-[var(--color-navy-900)] text-white rounded-xl ring-2 ring-accent/40"
     >
       <PresenceAvatars />
       <Canvas camera={{ position: [3, 3, 3] }}>

--- a/components/PagePrompt.tsx
+++ b/components/PagePrompt.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { useEffect } from 'react';
+export default function PagePrompt({ prompt }: { prompt: string }) {
+  useEffect(() => {
+    document.body.dataset.pagePrompt = prompt;
+    return () => {
+      delete document.body.dataset.pagePrompt;
+    };
+  }, [prompt]);
+  return null;
+}

--- a/components/layout/CopilotWrapper.tsx
+++ b/components/layout/CopilotWrapper.tsx
@@ -1,20 +1,8 @@
 'use client';
-import { useState } from 'react';
-import CopilotPanel from '../CopilotPanel';
 import { aiCopilotEnabled } from '../../app/lib/features';
+import { ChatWidget } from '../ui';
 
 export default function CopilotWrapper() {
-  const [open, setOpen] = useState(false);
   if (!aiCopilotEnabled) return null;
-  return (
-    <>
-      <button
-        className="fixed bottom-6 right-6 rounded-xl px-5 py-2 bg-accent text-white font-bold shadow-md hover:scale-105 transition"
-        onClick={() => setOpen(true)}
-      >
-        AI Copilot
-      </button>
-      <CopilotPanel open={open} onClose={() => setOpen(false)} />
-    </>
-  );
+  return <ChatWidget />;
 }

--- a/components/ui/BackgroundCanvas.tsx
+++ b/components/ui/BackgroundCanvas.tsx
@@ -1,0 +1,79 @@
+'use client';
+import { useRef, useEffect } from 'react';
+import clsx from 'clsx';
+
+export default function BackgroundCanvas({ className }: { className?: string }) {
+  const ref = useRef<HTMLCanvasElement>(null);
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    let width = canvas.offsetWidth;
+    let height = canvas.offsetHeight;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.scale(dpr, dpr);
+
+    const shapes = Array.from({ length: 25 }, () => ({
+      x: Math.random() * width,
+      y: Math.random() * height,
+      size: 20 + Math.random() * 40,
+      depth: 0.02 + Math.random() * 0.08,
+      type: Math.random() > 0.5 ? 'triangle' : 'hex',
+    }));
+
+    let pointer = { x: width / 2, y: height / 2 };
+    const draw = () => {
+      ctx.clearRect(0, 0, width, height);
+      ctx.strokeStyle = 'rgba(255,255,255,0.25)';
+      shapes.forEach((s) => {
+        ctx.save();
+        const dx = (pointer.x - width / 2) * s.depth;
+        const dy = (pointer.y - height / 2) * s.depth;
+        ctx.translate(s.x + dx, s.y + dy);
+        ctx.beginPath();
+        if (s.type === 'triangle') {
+          const r = s.size / 2;
+          ctx.moveTo(0, -r);
+          ctx.lineTo(-r, r);
+          ctx.lineTo(r, r);
+        } else {
+          const r = s.size / 2;
+          for (let i = 0; i < 6; i++) {
+            const angle = (i / 6) * Math.PI * 2;
+            ctx.lineTo(Math.cos(angle) * r, Math.sin(angle) * r);
+          }
+        }
+        ctx.closePath();
+        ctx.stroke();
+        ctx.restore();
+      });
+    };
+    const onMove = (e: MouseEvent) => {
+      pointer = { x: e.clientX, y: e.clientY };
+    };
+    window.addEventListener('mousemove', onMove);
+    let raf: number;
+    const loop = () => {
+      draw();
+      raf = requestAnimationFrame(loop);
+    };
+    loop();
+    const onResize = () => {
+      width = canvas.offsetWidth;
+      height = canvas.offsetHeight;
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.scale(dpr, dpr);
+    };
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('resize', onResize);
+      cancelAnimationFrame(raf);
+    };
+  }, []);
+  return <canvas ref={ref} className={clsx('absolute inset-0 -z-10', className)} />;
+}

--- a/components/ui/Hero3D.tsx
+++ b/components/ui/Hero3D.tsx
@@ -33,7 +33,7 @@ export default function Hero3D() {
       initial={{ opacity: 0, scale: 0.95 }}
       whileInView={{ opacity: 1, scale: 1 }}
       viewport={{ once: true }}
-      className="h-64 w-full bg-slate-700/20 rounded-xl"
+      className="h-64 w-full bg-slate-700/20 rounded-xl ring-2 ring-accent/40"
     >
       <Canvas camera={{ position: [0, 0, 4] }}>
         <ambientLight intensity={0.5} />

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -21,3 +21,6 @@ export { default as Skeleton } from "./Skeleton";
 export { default as LazyImage } from "./LazyImage";
 export { default as Drawer } from "./Drawer";
 export { default as StreamingText } from "./StreamingText";
+export { default as BackgroundCanvas } from "./BackgroundCanvas";
+export { default as ChatWidget } from "../ChatWidget";
+export { default as PagePrompt } from "../PagePrompt";


### PR DESCRIPTION
## Summary
- animate hero headline, add canvas pattern and refine text styles
- implement reusable BackgroundCanvas
- revamp CopilotWrapper with persistent ChatWidget
- allow pages to define prompts via PagePrompt component
- update tool cards and 3D canvases with consistent design

## Testing
- `npm test`
- `npm run lint` *(fails: react/jsx-no-comment-textnodes and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871e816be0883238d01fd55235d9d7a