### PR TITLE
Enhance navigation with glassmorphic tweaks

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -254,3 +254,13 @@ button:focus-visible {
 .animate-star-pulse {
   animation: star-pulse 4s ease-in-out infinite;
 }
+
+@keyframes pulse-slow {0%,100%{opacity:1}50%{opacity:.5}}
+.pulse-slow{animation:pulse-slow 3s ease-in-out infinite}
+
+
+/* Fluid headings */
+h1{font-size:clamp(2.25rem,5vw,3.5rem)}
+h2{font-size:clamp(1.75rem,4vw,2.5rem)}
+h3{font-size:clamp(1.5rem,3vw,2rem)}
+

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -1,0 +1,40 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export default function Breadcrumbs() {
+  const pathname = usePathname();
+  const segments = pathname.split('/').filter(Boolean);
+  const crumbs = segments.map((seg, i) => {
+    const href = '/' + segments.slice(0, i + 1).join('/');
+    const label = seg.charAt(0).toUpperCase() + seg.slice(1);
+    return { href, label };
+  });
+  if (!crumbs.length) return null;
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="fixed top-16 left-4 z-40 bg-white/40 dark:bg-gray-800/40 backdrop-blur-md px-3 py-1 rounded-lg text-sm shadow"
+    >
+      <ol className="flex space-x-1">
+        <li>
+          <Link href="/" className="hover:underline">
+            Home
+          </Link>
+        </li>
+        {crumbs.map((c, i) => (
+          <li key={c.href} className="flex items-center">
+            <span className="mx-1">/</span>
+            {i === crumbs.length - 1 ? (
+              <span aria-current="page">{c.label}</span>
+            ) : (
+              <Link href={c.href} className="hover:underline">
+                {c.label}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -22,7 +22,7 @@ export default function ChatWidget() {
     <>
       <button
         onClick={() => setOpen(true)}
-        className="fixed bottom-6 right-6 rounded-full w-14 h-14 bg-accent text-white flex items-center justify-center shadow-lg hover:scale-110 transition animate-bounce"
+        className="fixed bottom-6 right-6 rounded-full w-14 h-14 bg-accent text-white flex items-center justify-center shadow-lg hover:scale-110 transition pulse-slow"
       >
         <MessageCircle className="w-6 h-6" />
         <span className="sr-only">Ask AI</span>

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,17 +1,29 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { Menu, X, Shield, FilePlus } from "lucide-react";
 import Button from "./Button";
+import ThemeToggle from "./ui/ThemeToggle";
 
 export default function NavBar() {
   const [open, setOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+  useEffect(() => {
+    const handle = () => setScrolled(window.scrollY > 30);
+    handle();
+    window.addEventListener("scroll", handle);
+    return () => window.removeEventListener("scroll", handle);
+  }, []);
   const links = [
     { href: "/analysis", label: "Instant Roof Analysis", icon: Shield },
     { href: "/proposal", label: "Create Field Proposal", icon: FilePlus },
   ];
   return (
-    <header className="sticky top-0 z-50 bg-bg/80 backdrop-blur-lg">
+    <header
+      className={`sticky top-0 z-50 backdrop-blur-lg transition-colors ${
+        scrolled ? "bg-bg/80" : "bg-bg/40"
+      }`}
+    >
       <nav className="max-w-6xl mx-auto flex items-center justify-between p-4">
         <Link href="/" className="font-bold text-lg" aria-label="MyRoofGenius">
           MyRoofGenius
@@ -31,13 +43,16 @@ export default function NavBar() {
             Start Free Analysis
           </Button>
         </div>
-        <button
-          className="md:hidden p-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-          aria-label="Toggle menu"
-          onClick={() => setOpen(!open)}
-        >
-          {open ? <X /> : <Menu />}
-        </button>
+        <div className="flex items-center space-x-2">
+          <ThemeToggle />
+          <button
+            className="md:hidden p-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            aria-label="Toggle menu"
+            onClick={() => setOpen(!open)}
+          >
+            {open ? <X /> : <Menu />}
+          </button>
+        </div>
       </nav>
       {open && (
         <div className="md:hidden bg-bg border-t border-gray-200">
@@ -54,8 +69,9 @@ export default function NavBar() {
               </Link>
             ))}
           </div>
-          <div className="p-4 sticky bottom-0 bg-bg border-t border-gray-200">
-            <Button as="a" href="/get-started" className="w-full">
+          <div className="p-4 sticky bottom-0 bg-bg border-t border-gray-200 flex items-center justify-between">
+            <ThemeToggle />
+            <Button as="a" href="/get-started" className="w-full ml-2">
               Start Free Analysis
             </Button>
           </div>

--- a/components/layout/ClientLayout.tsx
+++ b/components/layout/ClientLayout.tsx
@@ -12,6 +12,7 @@ import { LocaleProvider } from "../../src/context/LocaleContext";
 import { CurrencyProvider } from "../../src/context/CurrencyContext";
 import DocumentLang from "../DocumentLang";
 import NavBar from "../NavBar";
+import Breadcrumbs from "../Breadcrumbs";
 import AnnouncementBanner from "../AnnouncementBanner";
 import ErrorBoundary from "../ErrorBoundary";
 import CopilotWrapper from "./CopilotWrapper";
@@ -54,6 +55,7 @@ export default function ClientLayout({ children }: { children: ReactNode }) {
                     {arModeEnabled ? (
                       <ARModeProvider>
                         <NavBar />
+                        <Breadcrumbs />
                         <AnnouncementBanner />
                         <main
                           id="main-content"
@@ -68,6 +70,7 @@ export default function ClientLayout({ children }: { children: ReactNode }) {
                     ) : (
                       <>
                         <NavBar />
+                        <Breadcrumbs />
                         <AnnouncementBanner />
                         <main
                           id="main-content"


### PR DESCRIPTION
## Summary
- add glassy breadcrumb navigation
- improve nav header with dark mode toggle and scroll opacity
- pulse animation for chat widget
- integrate breadcrumbs into layout
- add fluid typography styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68726db46ea48323af74a43f09f7bed6