### PR TITLE
Fix breadcrumbs pathname null issue

### DIFF
--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 export default function Breadcrumbs() {
-  const pathname = usePathname();
+  const pathname = usePathname() ?? "";
   const segments = pathname.split('/').filter(Boolean);
   const crumbs = segments.map((seg, i) => {
     const href = '/' + segments.slice(0, i + 1).join('/');


### PR DESCRIPTION
## Summary
- fix Breadcrumbs to handle null values from `usePathname`

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6872747a5f8c8323b7ffdaa89bc0c89f