### PR TITLE
Remove experimental starfield background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,7 +5,7 @@
 @layer base {
   body {
     @apply font-sans;
-    background: linear-gradient(180deg, #0a0a0a, #1a1a1a);
+    background: radial-gradient(circle at center, #101020, #000000);
     color: #e0e0e0;
     font-size: clamp(1rem, 2.5vw, 1.125rem);
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,13 +7,6 @@ import { maintenanceMode } from "./lib/features";
 import { Analytics } from "../components/ui";
 import { Analytics as VercelAnalytics } from "@vercel/analytics/react";
 
-const Starfield = dynamicImport(() => import("../components/Starfield"), {
-  ssr: false,
-});
-const RippleBackground = dynamicImport(
-  () => import("../components/RippleBackground"),
-  { ssr: false },
-);
 const ClientLayout = dynamicImport(
   () => import("../components/layout/ClientLayout"),
   { ssr: false },
@@ -160,8 +153,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           </div>
         ) : (
           <>
-            <Starfield />
-            <RippleBackground />
             <ClientLayout>{children}</ClientLayout>
             <Analytics />
             <VercelAnalytics />


### PR DESCRIPTION
## Summary
- remove Starfield and ripple effects from main layout
- restore simple radial gradient background

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68733f8a3888832391ac042a1c744a1f