### PR TITLE
Fix Galaxy background render

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,8 @@
 import dynamicImport from "next/dynamic";
 const HomeClient = dynamicImport(() => import("./HomeClient"), { ssr: false });
+const GalaxyCanvas = dynamicImport(() => import("../components/GalaxyCanvas"), {
+  ssr: false,
+});
 
 export const dynamic = "force-dynamic";
 
@@ -10,5 +13,10 @@ export const metadata = {
 };
 
 export default function HomePage() {
-  return <HomeClient />;
+  return (
+    <>
+      {typeof window !== "undefined" && <GalaxyCanvas />}
+      <HomeClient />
+    </>
+  );
 }

--- a/components/GalaxyCanvas.tsx
+++ b/components/GalaxyCanvas.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from "react";
+
+export default function GalaxyCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let width = canvas.offsetWidth;
+    let height = canvas.offsetHeight;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.scale(dpr, dpr);
+
+    const stars = Array.from({ length: 100 }, () => ({
+      x: Math.random() * width,
+      y: Math.random() * height,
+      size: Math.random() * 2 + 0.5,
+      speed: Math.random() * 0.5 + 0.1,
+    }));
+
+    let raf: number;
+    const render = () => {
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = "#fff";
+      for (const star of stars) {
+        star.y -= star.speed;
+        if (star.y < 0) star.y = height;
+        ctx.beginPath();
+        ctx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      raf = requestAnimationFrame(render);
+    };
+
+    render();
+
+    const handleResize = () => {
+      width = canvas.offsetWidth;
+      height = canvas.offsetHeight;
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.scale(dpr, dpr);
+    };
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="absolute inset-0 w-full h-full" />;
+}

--- a/tests/layout.spec.tsx
+++ b/tests/layout.spec.tsx
@@ -5,6 +5,10 @@ import { render } from '@testing-library/react';
 jest.mock('../components/ui', () => ({ Analytics: () => null }));
 jest.mock('../app/lib/sentry', () => ({}));
 jest.mock('@vercel/analytics/react', () => ({ Analytics: () => null }));
+jest.mock('../components/CopilotProvider', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
 jest.mock('next/font/google', () => ({
   Inter: () => ({ className: 'font', variable: '--font-body' }),
   EB_Garamond: () => ({ className: 'font', variable: '--font-heading' }),


### PR DESCRIPTION
## Summary
- add `<GalaxyCanvas>` component for client side star animation
- dynamically load the canvas in `app/page.tsx`
- mock `CopilotProvider` in layout test so Jest passes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873d545d9408323a653e5322585587e