### PR TITLE
Finish Line Sprint updates

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -202,7 +202,7 @@
 
 a:focus-visible,
 button:focus-visible {
-  outline: 2px solid #3b82f6; /* Accent-Blue-500 */
+  outline: 2px solid #4F9CF9;
   outline-offset: 2px;
 }
 
@@ -214,7 +214,7 @@ button:focus-visible {
   [role="button"],
   [tabindex]:not([tabindex="-1"])
 ):focus-visible {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid #4F9CF9;
   outline-offset: 2px;
 }
 
@@ -258,7 +258,7 @@ button:focus-visible {
 
 /* Trust Section */
 .trust {
-  background: var(--color-bg);
+  @apply bg-gradient-to-b from-[#002D5B] to-[#001A33];
   padding: 2rem 1rem;
   text-align: center;
 }
@@ -274,28 +274,28 @@ button:focus-visible {
 @keyframes star-pulse {
   0%,
   100% {
-    opacity: 0.8;
+    opacity: 0.96;
   }
   50% {
-    opacity: 0.4;
+    opacity: 0.92;
   }
 }
 
 .animate-star-pulse {
-  animation: star-pulse 4s ease-in-out infinite;
+  animation: star-pulse 8s ease-in-out infinite;
 }
 
 @keyframes pulse-slow {
   0%,
   100% {
-    opacity: 1;
+    opacity: 0.96;
   }
   50% {
-    opacity: 0.5;
+    opacity: 0.92;
   }
 }
 .pulse-slow {
-  animation: pulse-slow 3s ease-in-out infinite;
+  animation: pulse-slow 8s ease-in-out infinite;
 }
 
 /* Fluid headings */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ export const metadata = {
 
 export default function HomePage() {
   return (
-    <main className="relative z-0 overflow-hidden">
+    <main className="relative z-0 overflow-hidden pb-28 sm:pb-0">
       <HomeClient />
     </main>
   );

--- a/components/layout/ClientLayout.tsx
+++ b/components/layout/ClientLayout.tsx
@@ -65,7 +65,7 @@ export default function ClientLayout({ children }: { children: ReactNode }) {
                           <main
                             id="main-content"
                             tabIndex={-1}
-                            className="outline-none pb-24"
+                            className="outline-none pb-28 sm:pb-24"
                           >
                             <ErrorBoundary>{children}</ErrorBoundary>
                           </main>
@@ -80,7 +80,7 @@ export default function ClientLayout({ children }: { children: ReactNode }) {
                           <main
                             id="main-content"
                             tabIndex={-1}
-                            className="outline-none pb-24"
+                            className="outline-none pb-28 sm:pb-24"
                           >
                             <ErrorBoundary>{children}</ErrorBoundary>
                           </main>

--- a/components/marketing/TrustSection.tsx
+++ b/components/marketing/TrustSection.tsx
@@ -2,7 +2,7 @@
 import Image from "next/image";
 export default function TrustSection() {
   return (
-    <section className="trust">
+    <section className="trust bg-gradient-to-b from-[#002D5B] to-[#001A33]">
       <h2>Trusted by Roofing Pros</h2>
       <blockquote>
         "MyRoofGenius saved us $20k on project estimates!" – John, ABC Roofing

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -30,7 +30,7 @@ export default function Card({
     <motion.div
       {...motionProps}
       className={clsx(
-        "rounded-2xl p-6 min-h-[48px] shadow-[0px_8px_32px_rgba(0,0,0,0.1)]",
+        "rounded-2xl p-6 min-h-[48px] shadow-[0px_8px_32px_rgba(0,0,0,0.1)] hover:-translate-y-1 hover:shadow-lg",
         glass
           ? "glass border border-white/20 rounded-[14px] transition-transform hover:scale-105 hover:border-accent"
           : "bg-bg-card",

--- a/design-system/tokens.json
+++ b/design-system/tokens.json
@@ -9,7 +9,7 @@
     "color-warning-base": "rgb(var(--clr-warning-500) / <alpha-value>)",
     "color-danger-base": "rgb(var(--clr-danger-500) / <alpha-value>)",
     "color-text-primary": "var(--color-text)",
-    "color-text-secondary": "#6B7280"
+    "color-text-secondary": "#E6F0FF"
   },
   "spacing": {
     "spacing-0": "0px",


### PR DESCRIPTION
## Summary
- replace Trust section band with dark brand gradient and adjust animations
- improve subtitle contrast
- add hover depth for cards
- pad main content to avoid chat widget overlap

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874020d760c83239c009574904f62a1